### PR TITLE
Add registry parameter to build command

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -14,6 +14,12 @@ parameters:
       Path to the directory containing your Dockerfile and build context,
       defaults to . (working directory)
 
+  registry:
+    type: string
+    default: docker.io
+    description: >
+      Name of registry to use, defaults to docker.io
+
   image:
     type: string
     description: Name of image to build
@@ -37,5 +43,5 @@ steps:
         docker build \
           <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
           -f <<parameters.dockerfile>> -t \
-          <<parameters.image>>:<<parameters.tag>> \
+          <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
           <<parameters.path>>

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -112,6 +112,7 @@ steps:
   - build:
       dockerfile: <<parameters.dockerfile>>
       path: <<parameters.path>>
+      registry: <<parameters.registry>>
       image: <<parameters.image>>
       tag: <<parameters.tag>>
       extra_build_args: <<parameters.extra_build_args>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixes #2 

### Description

Add `registry` parameter to `build` command to match `push` command, enabling the `publish` job to work with 3rd party registries.
