### PR TITLE
Adding first shot at --cache-from

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -54,6 +54,13 @@ parameters:
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
 
+  cache_from:
+    type: string
+    default: ""
+    description: >
+      Comma separated list of containers to pull before build for --cache-from
+      https://docs.docker.com/engine/reference/commandline/build/
+
   debug:
     type: boolean
     default: false
@@ -69,11 +76,22 @@ steps:
             dockerfile: <<parameters.path>>/<<parameters.dockerfile>>
             debug: <<parameters.debug>>
 
-  - run:
-      name: <<parameters.step-name>>
-      command: |
-        docker build \
-          <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
-          -f <<parameters.path>>/<<parameters.dockerfile>> -t \
-          <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
-          <<parameters.path>>
+  - when:
+      condition: <<parameters.cache_from>>
+      steps:
+        - run: |
+            docker build \
+              <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
+              --cache-from <<parameters.cache_from>> \
+              -f <<parameters.path>>/<<parameters.dockerfile>> -t \
+              <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
+              <<parameters.path>>
+  - unless:
+      condition: <<parameters.cache_from>>
+      steps:
+        - run: |
+            docker build \
+              <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
+              -f <<parameters.path>>/<<parameters.dockerfile>> -t \
+              <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
+              <<parameters.path>>

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -80,6 +80,11 @@ steps:
       condition: <<parameters.cache_from>>
       steps:
         - run: |
+            echo "<<parameters.cache_from>>" | sed -n 1'p' | tr ',' '\n' | while read container; do
+              echo "Pulling ${container}";
+              docker pull ${container};
+            done
+
             docker build \
               <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
               --cache-from <<parameters.cache_from>> \

--- a/src/commands/pull.yml
+++ b/src/commands/pull.yml
@@ -1,0 +1,17 @@
+description: Pull one or more Docker images from a registry
+
+parameters:
+  containers:
+    type: string
+    default: ""
+    description: Comma separated list of containers to pull
+
+steps:
+  - when:
+      condition: <<parameters.containers>>
+      steps:
+        - run: |
+            echo "<<parameters.containers>>" | sed -n 1'p' | tr ',' '\n' | while read container; do
+              echo "Pulling ${container}";
+              docker pull ${container};
+            done

--- a/src/examples/custom-isolated-pull.yml
+++ b/src/examples/custom-isolated-pull.yml
@@ -1,0 +1,22 @@
+description: >
+  Use the pull command to pull one or more Docker containers
+
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+    jobs:
+      pull:
+        executor: docker/machine
+        steps:
+          - checkout
+
+          - docker/pull:
+              containers: ubuntu:16.04,ubuntu:18.04
+
+  workflows:
+    pull-containers:
+      jobs:
+        - pull

--- a/src/examples/with-cache-from.yml
+++ b/src/examples/with-cache-from.yml
@@ -1,0 +1,15 @@
+description: >
+  Build/publish a Docker image using --cache-from
+
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  workflows:
+    build-docker-image-only:
+      jobs:
+        - docker/publish:
+            image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+            cache_from: ubuntu:18.04,ubuntu:16.04

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -64,6 +64,13 @@ parameters:
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
 
+  cache_from:
+    type: string
+    default: ""
+    description: >
+      Comma separated list of containers to pull before build for --cache-from
+      https://docs.docker.com/engine/reference/commandline/build/
+
   after_checkout:
     description: Optional steps to run after checking out the code
     type: steps
@@ -118,6 +125,13 @@ steps:
             docker-password: <<parameters.docker-password>>
 
   - when:
+      name: Pull containers for cache_from
+      condition: <<parameters.cache_from>>
+      steps:
+        - pull:
+            containers: <<parameters.cache_from>>
+
+  - when:
       name: Run before_build lifecycle hook steps
       condition: <<parameters.before_build>>
       steps: <<parameters.before_build>>
@@ -128,6 +142,7 @@ steps:
       registry: <<parameters.registry>>
       image: <<parameters.image>>
       tag: <<parameters.tag>>
+      cache_from: <<parameters.cache_from>>
       extra_build_args: <<parameters.extra_build_args>>
       lint-dockerfile: <<parameters.lint-dockerfile>>
       treat-warnings-as-errors: <<parameters.treat-warnings-as-errors>>

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -125,13 +125,6 @@ steps:
             docker-password: <<parameters.docker-password>>
 
   - when:
-      name: Pull containers for cache_from
-      condition: <<parameters.cache_from>>
-      steps:
-        - pull:
-            containers: <<parameters.cache_from>>
-
-  - when:
       name: Run before_build lifecycle hook steps
       condition: <<parameters.before_build>>
       steps: <<parameters.before_build>>


### PR DESCRIPTION
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

I've had several repos now where I've wanted to add `--cache-from` for the build command, and normally this would work with extra_build_args, but then I always need to add an additional "before_build" step to pull the containers that I want to use. For a single build, this isn't a big deal. But for a complicated recipe where I have 5-6 instances of publish/docker, each with two containers for different cache_from, it gets a big tedious (see [here](https://github.com/nushell/nushell/blob/67b3d2aff82685c2b1b5e91dc1c817cacdb177b4/.circleci/config.yml)) for an example. 

Since using the cache is a fairly common need, and it will always be the case that a user needs to pull containers that are used for it, I thought it would be a good contribution to add an extra argument so the user can specify one or more containers (comma separated) for the `--cache-from` command.  To use, it would look something like:

```yaml
        - docker/publish:
            image: dinosaur/best-container-ever
            cache_from: ubuntu:18.04,ubuntu:16.04
```

Which is really easy for the user to write (and vary cache_from between jobs), but then on the backend it would be pulling those containers before build, and adding the `--cache-from` as a build argument (I used when and unless to try for an if else yaml functionality, take a look and please let me know if there is a better way to do this!)

I'm not super familiar with the more structured / multi-file yaml setup, so apologies in advance for mistakes :P I'll fix up anything that is needed for sure!