### PR TITLE
Use standard input to capture user passwords

### DIFF
--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -31,6 +31,6 @@ steps:
   - run:
       name: Docker login
       command: |
-        docker login \
-          -u "$<<parameters.docker-username>>" -p "$<<parameters.docker-password>>" \
+        echo "$<<parameters.docker-password>>" | docker login \
+          --username "$<<parameters.docker-username>>" --password-stdin \
           <<parameters.registry>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
Updates `docker login` to use `--password-stdin`.

Fixes #14

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

As per the motivation section above.