### PR TITLE
feat: add `--cache-from` container build flag in publish

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -29,8 +29,8 @@ parameters:
     type: boolean
     default: false
     description: >
-     If linting Dockerfile, treat linting warnings as errors (would trigger
-     an exist code and fail the CircleCI job)?
+      If linting Dockerfile, treat linting warnings as errors (would trigger
+      an exit code and fail the CircleCI job)?
 
   registry:
     type: string
@@ -46,6 +46,17 @@ parameters:
     type: string
     default: $CIRCLE_SHA1
     description: Image tag, defaults to the value of $CIRCLE_SHA1
+
+  cache_from:
+    type: string
+    default: ""
+    description: >
+      Images to consider as cache sources. Specified as comma separated values of
+      image and tag syntax. An implicit `docker pull` will be done for each image
+      specific to fetch the image. Thus, an explicit `docker pull` does not need
+      to be done.
+      For example, node:13,python:latest,openjdk:12,gcr.io/google-containers/busybox.
+      Please see https://docs.docker.com/engine/reference/commandline/build/
 
   extra_build_args:
     type: string
@@ -72,7 +83,13 @@ steps:
   - run:
       name: <<parameters.step-name>>
       command: |
+        IFS="," read -ra CACHE_FROM_IMAGES \<<< "<< parameters.cache_from >>"
+        for image in "${CACHE_FROM_IMAGES[@]}"; do
+          docker pull $image || echo "Failed to pull the specified image, $image. Ignoring..."
+        done
+
         docker build \
+          --cache-from "<<parameters.cache_from>>" \
           <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
           -f <<parameters.path>>/<<parameters.dockerfile>> -t \
           <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \

--- a/src/examples/build-with-cache-from.yml
+++ b/src/examples/build-with-cache-from.yml
@@ -1,0 +1,14 @@
+description: >
+  Build/publish a Docker image using --cache-from
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  workflows:
+    build-docker-image-only:
+      jobs:
+        - docker/publish:
+            image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+            cache_from: ubuntu:18.04,python:latest,gcr.io/google-containers/busybox

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -39,8 +39,8 @@ parameters:
     type: boolean
     default: false
     description: >
-     If linting Dockerfile, treat linting warnings as errors (would trigger
-     an exist code and fail the CircleCI job)?
+      If linting Dockerfile, treat linting warnings as errors (would trigger
+      an exit code and fail the CircleCI job)?
 
   image:
     type: string
@@ -56,6 +56,17 @@ parameters:
     default: docker.io
     description: >
       Name of registry to use, defaults to docker.io
+
+  cache_from:
+    type: string
+    default: ""
+    description: >
+      Images to consider as cache sources. Specified as comma separated values of
+      image and tag syntax. An implicit `docker pull` will be done for each image
+      specific to fetch the image. Thus, an explicit `docker pull` does not need
+      to be done.
+      For example, node:13,python:latest,openjdk:12,gcr.io/google-containers/busybox.
+      Please see https://docs.docker.com/engine/reference/commandline/build/
 
   extra_build_args:
     type: string
@@ -128,6 +139,7 @@ steps:
       registry: <<parameters.registry>>
       image: <<parameters.image>>
       tag: <<parameters.tag>>
+      cache_from: <<parameters.cache_from>>
       extra_build_args: <<parameters.extra_build_args>>
       lint-dockerfile: <<parameters.lint-dockerfile>>
       treat-warnings-as-errors: <<parameters.treat-warnings-as-errors>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
Allows the publish job to get an optional performance boost by using Docker's `--cache-from` flag.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Added `--cache-from` to container build in publish job.

Resolves #15 .