### PR TITLE
Fix install-docker-tools moving workspace files

### DIFF
--- a/src/commands/install-docker.yml
+++ b/src/commands/install-docker.yml
@@ -76,16 +76,18 @@ steps:
         DOCKER_BINARY_URL="https://download.docker.com/$PLATFORM/static/stable/x86_64/docker-$DOCKER_VERSION_NUMBER.tgz"
 
         # download binary tarball
-        curl --output docker.tgz \
+        DOWNLOAD_DIR="$(mktemp --directory)"
+        DOWNLOAD_FILE="${DOWNLOAD_DIR}/docker.tgz"
+        curl --output "$DOWNLOAD_FILE" \
           --silent --show-error --location --fail --retry 3 \
           "$DOCKER_BINARY_URL"
 
-        tar xf docker.tgz && rm -f docker.tgz
+        tar xf "$DOWNLOAD_FILE" -C "$DOWNLOAD_DIR" && rm -f "$DOWNLOAD_FILE"
 
         # install Docker binaries
-        BINARIES=$(ls docker)
-        $SUDO mv docker/* <<parameters.install-dir>>
-        $SUDO rm -rf docker
+        BINARIES=$(ls "${DOWNLOAD_DIR}/docker")
+        $SUDO mv "$DOWNLOAD_DIR"/docker/* <<parameters.install-dir>>
+        $SUDO rm -rf "$DOWNLOAD_DIR"
 
         for binary in $BINARIES
         do

--- a/src/commands/install-docker.yml
+++ b/src/commands/install-docker.yml
@@ -76,7 +76,7 @@ steps:
         DOCKER_BINARY_URL="https://download.docker.com/$PLATFORM/static/stable/x86_64/docker-$DOCKER_VERSION_NUMBER.tgz"
 
         # download binary tarball
-        DOWNLOAD_DIR="$(mktemp --directory)"
+        DOWNLOAD_DIR="$(mktemp -d)"
         DOWNLOAD_FILE="${DOWNLOAD_DIR}/docker.tgz"
         curl --output "$DOWNLOAD_FILE" \
           --silent --show-error --location --fail --retry 3 \


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

If user has a directory named `docker` in their workspace/repository, it would be manipulated unnecessarily by `install-docker-tools`. This can be avoided by using a temporary download directory for Docker binaries.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Closes #13 

- Fix install-docker-tools moving workspace files
  - Don't download Docker binaries into the workspace but into a temporary directory
  - Don't attempt to remove directories named "docker" inside the workspace
