### PR TITLE
addition of  docker-context

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -16,7 +16,7 @@ parameters:
     type: string
     default: .
     description: >
-      Path to the directory containing your Dockerfile and build context,
+      Path to the directory containing your Dockerfile,
       defaults to . (working directory)
 
   lint-dockerfile:
@@ -59,7 +59,15 @@ parameters:
     default: false
     description: >
       Extra output for orb developers
-
+      
+  docker-context:
+    type: string
+    default: .
+    description: >
+      Path to the directory containing your build context,
+      defaults to . (working directory)     
+      
+      
 steps:
   - when:
       condition: <<parameters.lint-dockerfile>>
@@ -76,4 +84,4 @@ steps:
           <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
           -f <<parameters.path>>/<<parameters.dockerfile>> -t \
           <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
-          <<parameters.path>>
+          <<parameters.docker-context>>


### PR DESCRIPTION
separation of build context and docker file path

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

add docker-context to build command allowing context to be set at a different level than the docker file, so that nested builds can include from parent directories

### Description

add docker-context to build command
