### PR TITLE
Adding cache_from argument

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,18 @@ jobs:
                 install-goss-dgoss: <<parameters.install-goss>>
                 goss-version: <<parameters.goss-version>>
                 debug: <<parameters.debug>>
+  test-pull:
+    executor: orb-tools/node-cci
+
+    steps:
+      - setup_remote_docker
+
+      - docker/pull:
+          images: cimg/base:stable,ubuntu:18.04
+
+      - docker/pull:
+          images: cimg/base:stable,cimg/base:not_exists,cimg/go:stable
+          ignore-docker-pull-error: true
 
 integration-dev_filters: &integration-dev_filters
   branches:
@@ -95,6 +107,8 @@ prod-deploy_requires: &prod-deploy_requires
     hadolint-master,
     publish-machine-master,
     publish-docker-cache-from-master,
+    publish-docker-cache-not-found-master,
+    test-pull-master,
     latest-alpine-master,
     older-alpine-master,
     latest-machine-master,
@@ -197,9 +211,26 @@ workflows:
           dockerfile: test.Dockerfile
           image: circlecipublic/docker-orb-test
           tag: dev-$CIRCLE_SHA1
-          cache_from: circlecipublic/docker-orb-test:$CIRCLE_SHA1
+          cache_from: circlecipublic/docker-orb-test:dev-$CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
+          filters: *integration-dev_filters
+
+      - docker/publish:
+          name: publish-docker-cache-not-found-dev
+          executor: docker/docker
+          context: orb-publishing
+          use-remote-docker: true
+          dockerfile: test.Dockerfile
+          image: circlecipublic/docker-orb-test
+          tag: dev-$CIRCLE_SHA1-2
+          cache_from: circlecipublic/docker-orb-test:not-exists
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          filters: *integration-dev_filters
+
+      - test-pull:
+          name: test-pull-dev
           filters: *integration-dev_filters
 
       # alpine
@@ -440,7 +471,24 @@ workflows:
           cache_from: circlecipublic/docker-orb-test:$CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
-          filters: *integration-dev_filters
+          filters: *integration-master_filters
+
+      - docker/publish:
+          name: publish-docker-cache-not-found-master
+          executor: docker/docker
+          context: orb-publishing
+          use-remote-docker: true
+          dockerfile: test.Dockerfile
+          image: circlecipublic/docker-orb-test
+          tag: $CIRCLE_SHA1-2
+          cache_from: circlecipublic/docker-orb-test:not-exists
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          filters: *integration-master_filters
+
+      - test-pull:
+          name: test-pull-master
+          filters: *integration-master_filters
 
       # alpine
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ prod-deploy_requires: &prod-deploy_requires
   [
     hadolint-master,
     publish-machine-master,
-    publish-docker-master,
+    publish-docker-cache-from-master,
     latest-alpine-master,
     older-alpine-master,
     latest-machine-master,
@@ -182,7 +182,22 @@ workflows:
           use-remote-docker: true
           dockerfile: test.Dockerfile
           image: circlecipublic/docker-orb-test
-          tag: $CIRCLE_BUILD_NUM-$CIRCLE_SHA1
+          tag: dev-$CIRCLE_SHA1
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          filters: *integration-dev_filters
+
+      - docker/publish:
+          name: publish-docker-cache-from-dev
+          requires:
+            - publish-docker-dev
+          executor: docker/docker
+          context: orb-publishing
+          use-remote-docker: true
+          dockerfile: test.Dockerfile
+          image: circlecipublic/docker-orb-test
+          tag: dev-$CIRCLE_SHA1
+          cache_from: circlecipublic/docker-orb-test:$CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
           filters: *integration-dev_filters
@@ -407,10 +422,25 @@ workflows:
           use-remote-docker: true
           dockerfile: test.Dockerfile
           image: circlecipublic/docker-orb-test
-          tag: $CIRCLE_BUILD_NUM-$CIRCLE_SHA1
+          tag: $CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
           filters: *integration-master_filters
+
+      - docker/publish:
+          name: publish-docker-cache-from-master
+          requires:
+            - publish-docker-master
+          executor: docker/docker
+          context: orb-publishing
+          use-remote-docker: true
+          dockerfile: test.Dockerfile
+          image: circlecipublic/docker-orb-test
+          tag: $CIRCLE_SHA1
+          cache_from: circlecipublic/docker-orb-test:$CIRCLE_SHA1
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          filters: *integration-dev_filters
 
       # alpine
       - test:

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -58,7 +58,7 @@ parameters:
     type: string
     default: ""
     description: >
-      Comma separated list of containers, images will first be pulled, then 
+      Comma separated list of containers, images will first be pulled, then
       passed as the --cache-from build argument
       https://docs.docker.com/engine/reference/commandline/build/
 

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -58,7 +58,7 @@ parameters:
     type: string
     default: ""
     description: >
-      Comma separated list of containers, images will first be pulled, then
+      Comma separated list of images, images will first be pulled, then
       passed as the --cache-from build argument
       https://docs.docker.com/engine/reference/commandline/build/
 
@@ -81,9 +81,9 @@ steps:
       condition: <<parameters.cache_from>>
       steps:
         - run: |
-            echo "<<parameters.cache_from>>" | sed -n 1'p' | tr ',' '\n' | while read container; do
-              echo "Pulling ${container}";
-              docker pull ${container};
+            echo "<<parameters.cache_from>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
+              echo "Pulling ${image}";
+              docker pull ${image} || exit 0
             done
 
             docker build \

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -54,6 +54,14 @@ parameters:
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
 
+  cache_from:
+    type: string
+    default: ""
+    description: >
+      Comma separated list of containers, images will first be pulled, then 
+      passed as the --cache-from build argument
+      https://docs.docker.com/engine/reference/commandline/build/
+
   debug:
     type: boolean
     default: false
@@ -69,11 +77,27 @@ steps:
             dockerfile: <<parameters.path>>/<<parameters.dockerfile>>
             debug: <<parameters.debug>>
 
-  - run:
-      name: <<parameters.step-name>>
-      command: |
-        docker build \
-          <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
-          -f <<parameters.path>>/<<parameters.dockerfile>> -t \
-          <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
-          <<parameters.path>>
+  - when:
+      condition: <<parameters.cache_from>>
+      steps:
+        - run: |
+            echo "<<parameters.cache_from>>" | sed -n 1'p' | tr ',' '\n' | while read container; do
+              echo "Pulling ${container}";
+              docker pull ${container};
+            done
+
+            docker build \
+              <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
+              --cache-from <<parameters.cache_from>> \
+              -f <<parameters.path>>/<<parameters.dockerfile>> -t \
+              <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
+              <<parameters.path>>
+  - unless:
+      condition: <<parameters.cache_from>>
+      steps:
+        - run: |
+            docker build \
+              <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
+              -f <<parameters.path>>/<<parameters.dockerfile>> -t \
+              <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
+              <<parameters.path>>

--- a/src/commands/pull.yml
+++ b/src/commands/pull.yml
@@ -1,17 +1,21 @@
 description: Pull one or more Docker images from a registry
 
 parameters:
-  containers:
+  images:
     type: string
     default: ""
-    description: Comma separated list of containers to pull
+    description: Comma separated list of images to pull
+  ignore-docker-pull-error:
+    type: boolean
+    default: false
+    description: Ignores errors from docker pull command
 
 steps:
   - when:
-      condition: <<parameters.containers>>
+      condition: <<parameters.images>>
       steps:
         - run: |
-            echo "<<parameters.containers>>" | sed -n 1'p' | tr ',' '\n' | while read container; do
-              echo "Pulling ${container}";
-              docker pull ${container};
+            echo "<<parameters.images>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
+              echo "Pulling ${image}";
+              docker pull ${image} <<#parameters.ignore-docker-pull-error>>|| exit 0<</parameters.ignore-docker-pull-error>>
             done

--- a/src/commands/pull.yml
+++ b/src/commands/pull.yml
@@ -1,0 +1,17 @@
+description: Pull one or more Docker images from a registry
+
+parameters:
+  containers:
+    type: string
+    default: ""
+    description: Comma separated list of containers to pull
+
+steps:
+  - when:
+      condition: <<parameters.containers>>
+      steps:
+        - run: |
+            echo "<<parameters.containers>>" | sed -n 1'p' | tr ',' '\n' | while read container; do
+              echo "Pulling ${container}";
+              docker pull ${container};
+            done

--- a/src/examples/custom-pull.yml
+++ b/src/examples/custom-pull.yml
@@ -1,0 +1,21 @@
+description: >
+  Use the pull command to pull one or more Docker containers
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+    jobs:
+      pull:
+        executor: docker/machine
+        steps:
+          - checkout
+
+          - docker/pull:
+              containers: ubuntu:16.04,ubuntu:18.04
+
+  workflows:
+    pull-containers:
+      jobs:
+        - pull

--- a/src/examples/custom-pull.yml
+++ b/src/examples/custom-pull.yml
@@ -1,5 +1,5 @@
 description: >
-  Use the pull command to pull one or more Docker containers
+  Use the pull command to pull one or more Docker images
 usage:
   version: 2.1
 
@@ -13,9 +13,9 @@ usage:
           - checkout
 
           - docker/pull:
-              containers: ubuntu:16.04,ubuntu:18.04
+              images: ubuntu:16.04,ubuntu:18.04
 
   workflows:
-    pull-containers:
+    pull-images:
       jobs:
         - pull

--- a/src/examples/with-cache-from.yml
+++ b/src/examples/with-cache-from.yml
@@ -1,0 +1,14 @@
+description: >
+  Build/publish a Docker image using --cache-from
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  workflows:
+    build-docker-image-only:
+      jobs:
+        - docker/publish:
+            image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+            cache_from: ubuntu:18.04,ubuntu:16.04

--- a/src/examples/with-cache-from.yml
+++ b/src/examples/with-cache-from.yml
@@ -11,4 +11,5 @@ usage:
       jobs:
         - docker/publish:
             image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-            cache_from: ubuntu:18.04,ubuntu:16.04
+            tag: latest
+            cache_from: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:latest

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -64,6 +64,13 @@ parameters:
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
 
+  cache_from:
+    type: string
+    default: ""
+    description: >
+      Comma separated list of containers to pull before build for --cache-from
+      https://docs.docker.com/engine/reference/commandline/build/
+
   after_checkout:
     description: Optional steps to run after checking out the code
     type: steps
@@ -128,6 +135,7 @@ steps:
       registry: <<parameters.registry>>
       image: <<parameters.image>>
       tag: <<parameters.tag>>
+      cache_from: <<parameters.cache_from>>
       extra_build_args: <<parameters.extra_build_args>>
       lint-dockerfile: <<parameters.lint-dockerfile>>
       treat-warnings-as-errors: <<parameters.treat-warnings-as-errors>>

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -68,7 +68,7 @@ parameters:
     type: string
     default: ""
     description: >
-      Comma separated list of containers to pull before build for --cache-from
+      Comma separated list of images to pull before build for --cache-from
       https://docs.docker.com/engine/reference/commandline/build/
 
   after_checkout:


### PR DESCRIPTION
This is a redo of #16 - with all of the same changes but minus the messy history. I was upset that the work got messy, and wanted the changes to be represented in one clean commit, and am doing that here. 

@KyleTryon as noted in previous discussion, I've added the docker pull to be done by build, which is the command done by publish, so a user doing a custom build step will still get it. The pull command is also added as a separate command. It may be trivial to do, but it seems like it could still be useful and read nicely in some custom pipeline. Instead of needing three lines for three docker pull commands, you just add the list of comma separated containers!

----------------------------------------------------------------

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

I've had several repos now where I've wanted to add `--cache-from` for the build command, and normally this would work with extra_build_args, but then I always need to add an additional "before_build" step to pull the containers that I want to use. For a single build, this isn't a big deal. But for a complicated recipe where I have 5-6 instances of publish/docker, each with two containers for different cache_from, it gets a big tedious (see [here](https://github.com/nushell/nushell/blob/67b3d2aff82685c2b1b5e91dc1c817cacdb177b4/.circleci/config.yml)) for an example. 

Since using the cache is a fairly common need, and it will always be the case that a user needs to pull containers that are used for it, I thought it would be a good contribution to add an extra argument so the user can specify one or more containers (comma separated) for the `--cache-from` command.  To use, it would look something like:

```yaml
        - docker/publish:
            image: dinosaur/best-container-ever
            cache_from: ubuntu:18.04,ubuntu:16.04
```

Which is really easy for the user to write (and vary cache_from between jobs), but then on the backend it would be pulling those containers before build, and adding the `--cache-from` as a build argument (I used when and unless to try for an if else yaml functionality, take a look and please let me know if there is a better way to do this!)

I'm not super familiar with the more structured / multi-file yaml setup, so apologies in advance for mistakes :P I'll fix up anything that is needed for sure!
