### PR TITLE
Add digest-path parameter to push command

### DIFF
--- a/src/commands/push.yml
+++ b/src/commands/push.yml
@@ -21,8 +21,18 @@ parameters:
     default: $CIRCLE_SHA1
     description: Image tag, defaults to the value of $CIRCLE_SHA1
 
+  digest-path:
+    type: string
+    description: The path to save the RepoDigest of the pushed image
+    default: ""
+
 steps:
   - deploy:
       name: <<parameters.step-name>>
       command: |
         docker push <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>>
+
+        if [ -n "<<parameters.digest-path>>" ]; then
+          mkdir -p "$(dirname <<parameters.digest-path>>)"
+          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> > "<<parameters.digest-path>>"
+        fi

--- a/src/examples/build-push-digest.yml
+++ b/src/examples/build-push-digest.yml
@@ -19,8 +19,6 @@ usage:
             image: my_repo/orb-test
         - docker/push:
             image: my_repo/orb-test
-        - docker/push:
-            image: my_repo/orb-test
             digest-path: /tmp/digest.txt
         - run:
             command: |

--- a/src/examples/build-push-digest.yml
+++ b/src/examples/build-push-digest.yml
@@ -1,0 +1,32 @@
+description: >
+  Build and push an image, save the digest to a file
+  and echo the file.
+
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  jobs:
+    build-and-push:
+      executor: docker/docker
+      steps:
+        - setup_remote_docker
+        - checkout
+        - docker/check
+        - docker/build:
+            image: my_repo/orb-test
+        - docker/push:
+            image: my_repo/orb-test
+        - docker/push:
+            image: my_repo/orb-test
+            digest-path: /tmp/digest.txt
+        - run:
+            command: |
+              echo "Digest is: $(</tmp/digest.txt)"
+
+  workflows:
+    commit:
+      jobs:
+        - build-and-push


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Docker images in a registry have an immutable identifier generated by
the registry using a hash of the image manifest. This is very useful
for identifying an exact image.

This digest is returned by the registry when an image is pushed and
added to the local image metadata by the docker engine, which is our
opportunity to save it.

See https://success.docker.com/article/images-tagging-vs-digests

Specifically, this will let you use the digest when deploying an image and
avoid any problems with mutable tags.

### Description

Add the `digest-path` parameter to `push` command.
This parameter can be used to save the digest of an image to a file.

Subsequent commands can read this file to use the digest. The contents of the file looks like:
```
my_repo/orb-test@sha256:07891cedde37fd3719fd40aa3b5ad722a86b9abf8e06e99b1fef6da65f61323f
```
