### PR TITLE
Fix `docker@0.5.15`: allow pull to continue for rest of the images after a pull error

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -83,7 +83,7 @@ steps:
         - run: |
             echo "<<parameters.cache_from>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
               echo "Pulling ${image}";
-              docker pull ${image} || exit 0
+              docker pull ${image} || true
             done
 
             docker build \

--- a/src/commands/pull.yml
+++ b/src/commands/pull.yml
@@ -17,5 +17,5 @@ steps:
         - run: |
             echo "<<parameters.images>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
               echo "Pulling ${image}";
-              docker pull ${image} <<#parameters.ignore-docker-pull-error>>|| exit 0<</parameters.ignore-docker-pull-error>>
+              docker pull ${image} <<#parameters.ignore-docker-pull-error>>|| true<</parameters.ignore-docker-pull-error>>
             done


### PR DESCRIPTION
When ignoring docker pull errors, allow pulling the rest of the images if one fails to be pulled
