### PR TITLE
Add support for build/push using multiple tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,18 @@ workflows:
           docker-password: DOCKER_PASS
           filters: *integration-dev_filters
 
+        - docker/publish:
+          name: publish-multiple-tag-dev
+          executor: docker/docker
+          context: orb-publishing
+          use-remote-docker: true
+          dockerfile: test.Dockerfile
+          image: circlecipublic/docker-orb-test
+          tag: dev,$CIRCLE_SHA1,dev-${CIRCLE_SHA1}
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          filters: *integration-dev_filters
+
       - test-pull:
           name: test-pull-dev
           filters: *integration-dev_filters

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -86,18 +86,30 @@ steps:
               docker pull ${image} || true
             done
 
+            docker_tag_args=""
+            IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+            for tag in "${DOCKER_TAGS[@]}"; do
+              docker_tag_args="$docker_tag_args -t $<<parameters.registry>>/<<parameters.image>>:${tag}"
+            done
+
             docker build \
               <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
               --cache-from <<parameters.cache_from>> \
-              -f <<parameters.path>>/<<parameters.dockerfile>> -t \
-              <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
+              -f <<parameters.path>>/<<parameters.dockerfile>> \
+              $docker_tag_args \
               <<parameters.path>>
   - unless:
       condition: <<parameters.cache_from>>
       steps:
         - run: |
+            docker_tag_args=""
+            IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+            for tag in "${DOCKER_TAGS[@]}"; do
+              docker_tag_args="$docker_tag_args -t $<<parameters.registry>>/<<parameters.image>>:${tag}"
+            done
+
             docker build \
               <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
-              -f <<parameters.path>>/<<parameters.dockerfile>> -t \
-              <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> \
+              -f <<parameters.path>>/<<parameters.dockerfile>> \
+              $docker_tag_args
               <<parameters.path>>

--- a/src/commands/push.yml
+++ b/src/commands/push.yml
@@ -19,7 +19,7 @@ parameters:
   tag:
     type: string
     default: $CIRCLE_SHA1
-    description: Image tag, defaults to the value of $CIRCLE_SHA1
+    description: Comma-separated list of image tag, defaults to the value of $CIRCLE_SHA1
 
   digest-path:
     type: string
@@ -30,7 +30,10 @@ steps:
   - deploy:
       name: <<parameters.step-name>>
       command: |
-        docker push <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>>
+        IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+        for tag in "${DOCKER_TAGS[@]}"; do
+          docker push <<parameters.registry>>/<< parameters.image>>:${tag}
+        done
 
         if [ -n "<<parameters.digest-path>>" ]; then
           mkdir -p "$(dirname <<parameters.digest-path>>)"

--- a/src/examples/with-multiple-tags.yml
+++ b/src/examples/with-multiple-tags.yml
@@ -1,0 +1,15 @@
+description: >
+  Build/publish a Docker image with extra build arguments
+
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  workflows:
+    build-docker-image-only:
+      jobs:
+        - docker/publish:
+            image:  $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+            tag: tag1,tag2,tag3

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -49,7 +49,7 @@ parameters:
   tag:
     type: string
     default: $CIRCLE_SHA1
-    description: Image tag, defaults to the value of $CIRCLE_SHA1
+    description: Comma-separated list of image tags, defaults to the value of $CIRCLE_SHA1
 
   registry:
     type: string


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
See issue #36 - it's currently not possible to build or push images using multiple tags (with a single command).

### Description
- Change docker build and push commands to iterate over a comma-separated list of tags
- Update README to reflect these changes
- Add integration test step to cover case with multiple tags