### PR TITLE
Fix multi tag builds

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -105,7 +105,7 @@ steps:
             docker_tag_args=""
             IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
             for tag in "${DOCKER_TAGS[@]}"; do
-              docker_tag_args="$docker_tag_args -t $<<parameters.registry>>/<<parameters.image>>:${tag}"
+              docker_tag_args='"$docker_tag_args" -t "$<<parameters.registry>>/<<parameters.image>>:${tag}"'
             done
 
             echo "$docker_tag_args"

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -92,8 +92,7 @@ steps:
               docker_tag_args="$docker_tag_args -t $<<parameters.registry>>/<<parameters.image>>:${tag}"
             done
 
-            docker build \
-              <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
+            docker build <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
               --cache-from <<parameters.cache_from>> \
               -f <<parameters.path>>/<<parameters.dockerfile>> \
               $docker_tag_args \
@@ -108,8 +107,7 @@ steps:
               docker_tag_args="$docker_tag_args -t <<parameters.registry>>/<<parameters.image>>:${tag}"
             done
 
-            docker build \
-              <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
+            docker build <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
               -f <<parameters.path>>/<<parameters.dockerfile>> \
-              $docker_tag_args
+              $docker_tag_args \
               <<parameters.path>>

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -108,6 +108,8 @@ steps:
               docker_tag_args="$docker_tag_args -t $<<parameters.registry>>/<<parameters.image>>:${tag}"
             done
 
+            echo "$docker_tag_args"
+
             docker build \
               <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
               -f <<parameters.path>>/<<parameters.dockerfile>> \

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -80,34 +80,40 @@ steps:
   - when:
       condition: <<parameters.cache_from>>
       steps:
-        - run: |
-            echo "<<parameters.cache_from>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
-              echo "Pulling ${image}";
-              docker pull ${image} || true
-            done
+        - run:
+            name: Docker build
+            command: |
+              echo "<<parameters.cache_from>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
+                echo "Pulling ${image}";
+                docker pull ${image} || true
+              done
 
-            docker_tag_args=""
-            IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
-            for tag in "${DOCKER_TAGS[@]}"; do
-              docker_tag_args="$docker_tag_args -t $<<parameters.registry>>/<<parameters.image>>:${tag}"
-            done
+              docker_tag_args=""
 
-            docker build <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
-              --cache-from <<parameters.cache_from>> \
-              -f <<parameters.path>>/<<parameters.dockerfile>> \
-              $docker_tag_args \
-              <<parameters.path>>
+              IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+              for tag in "${DOCKER_TAGS[@]}"; do
+                docker_tag_args="$docker_tag_args -t <<parameters.registry>>/<<parameters.image>>:${tag}"
+              done
+
+              docker build <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
+                --cache-from <<parameters.cache_from>> \
+                -f <<parameters.path>>/<<parameters.dockerfile>> \
+                $docker_tag_args \
+                <<parameters.path>>
   - unless:
       condition: <<parameters.cache_from>>
       steps:
-        - run: |
-            docker_tag_args=""
-            IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
-            for tag in "${DOCKER_TAGS[@]}"; do
-              docker_tag_args="$docker_tag_args -t <<parameters.registry>>/<<parameters.image>>:${tag}"
-            done
+        - run:
+            name: Docker build
+            command: |
+              docker_tag_args=""
 
-            docker build <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
-              -f <<parameters.path>>/<<parameters.dockerfile>> \
-              $docker_tag_args \
-              <<parameters.path>>
+              IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+              for tag in "${DOCKER_TAGS[@]}"; do
+                docker_tag_args="$docker_tag_args -t <<parameters.registry>>/<<parameters.image>>:${tag}"
+              done
+
+              docker build <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \
+                -f <<parameters.path>>/<<parameters.dockerfile>> \
+                $docker_tag_args \
+                <<parameters.path>>

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -105,10 +105,8 @@ steps:
             docker_tag_args=""
             IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
             for tag in "${DOCKER_TAGS[@]}"; do
-              docker_tag_args='"$docker_tag_args" -t "$<<parameters.registry>>/<<parameters.image>>:${tag}"'
+              docker_tag_args="$docker_tag_args -t <<parameters.registry>>/<<parameters.image>>:${tag}"
             done
-
-            echo "$docker_tag_args"
 
             docker build \
               <<#parameters.extra_build_args>><<parameters.extra_build_args>><</parameters.extra_build_args>> \


### PR DESCRIPTION
https://github.com/CircleCI-Public/docker-orb/pull/38 introduces multi-tag builds but there are some nitpicky bash syntax / linebreak issues causing jobs to fail... this fixes them, also adds a step name for the `docker build` command, to make output in the UI nicer