### PR TITLE
Fix dockerlint command documentation

### DIFF
--- a/src/commands/dockerlint.yml
+++ b/src/commands/dockerlint.yml
@@ -1,14 +1,7 @@
 description: >
-  Install hadolint and lint a given Dockerfile
+  Install dockerlint and lint a given Dockerfile
 
 parameters:
-  version:
-    type: string
-    default: latest
-    description: >
-      Version of hadolint to install, defaults to the latest release:
-      https://github.com/hadolint/hadolint/releases
-
   dockerfile:
     type: string
     default: Dockerfile
@@ -21,7 +14,7 @@ parameters:
     type: boolean
     default: false
     description: >
-      Treat linting warnings as errors (would trigger an exist code and
+      Treat linting warnings as errors (would trigger an exit code and
       fail the CircleCI job)?
 
   debug:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

`dockerlint` command currently has documentation referencing `hadolint`, instead of `dockerlint`, as noted by @jeff-knurek (https://github.com/CircleCI-Public/docker-orb/issues/40)

### Description

update documentation to correctly apply to `dockerlint`
