### PR TITLE
Add DLC to Docker executor example

### DIFF
--- a/src/examples/custom-name-tag-executor.yml
+++ b/src/examples/custom-name-tag-executor.yml
@@ -19,5 +19,6 @@ usage:
               image: circleci/node
               tag: boron-browsers
             use-remote-docker: true
+            remote-docker-dlc: true
             image:  my/image
             tag: my-tag


### PR DESCRIPTION
We've added the ability to specify DLC for this orb's `publish` job,
when using a Docker-based executor; add an example to note this
functionality.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
