### PR TITLE
Add update description command

### DIFF
--- a/src/commands/update.yml
+++ b/src/commands/update.yml
@@ -1,0 +1,55 @@
+description: Update a Docker image's description on Docker Hub
+
+parameters:
+  readme:
+    type: string
+    default: README.md
+    description: Name of the file containing the image description to update, defaults to README.md
+
+  path:
+    type: string
+    default: .
+    description: >
+      Path to the directory containing your Dockerfile and build context,
+      defaults to . (working directory)
+
+  registry:
+    type: string
+    default: docker.io
+    description: >
+      Name of registry to use, defaults to docker.io
+
+  image:
+    type: string
+    description: Name of image to push
+
+  docker-username:
+    type: env_var_name
+    default: DOCKER_LOGIN
+    description: >
+      Name of environment variable storing your Docker username
+
+  docker-password:
+    type: env_var_name
+    default: DOCKER_PASSWORD
+    description: >
+      Name of environment variable storing your Docker password
+
+steps:
+  - deploy:
+      name: Update description
+      command: |
+        if [ "<<parameters.registry>>" != "docker.io" ]; then
+          echo "Registry is not set to Docker Hub. Exiting"
+          exit 1
+        fi
+        DESCRIPTION="<<parameters.path>>/<<parameters.readme>>"
+        PAYLOAD="username=$<<parameters.docker-username>>&password=$<<parameters.docker-password>>"
+        JWT=$(curl -s -d $PAYLOAD https://hub.docker.com/v2/users/login/ | jq -r .token)
+        HEADER="Authorization: JWT $JWT"
+        URL="https://hub.docker.com/v2/repositories/<<parameters.image>>/"
+        STATUS=$(curl -s -o /dev/null -w %{http_code} -X PATCH -H "$HEADER" --data-urlencode full_description@$DESCRIPTION $URL)
+        if [ $STATUS -ne 200 ]; then
+          echo "Could not update image description"
+          exit 1
+        fi

--- a/src/examples/build-without-updating.yml
+++ b/src/examples/build-without-updating.yml
@@ -1,0 +1,15 @@
+description: >
+  Build and publish, but don't update the description of an image using the publish job
+
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  workflows:
+    build-docker-image-only:
+      jobs:
+        - docker/publish:
+            image:  $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+            update-description: false

--- a/src/examples/custom-readme-file.yml
+++ b/src/examples/custom-readme-file.yml
@@ -1,0 +1,16 @@
+description: >
+  Build, deploy, and update the description of a Docker image with a non-standard description file
+
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  workflows:
+    build-and-publish-docker-image:
+      jobs:
+        - docker/publish:
+            readme: my.README.md
+            path: path/to/Docker/build/context
+            image:  $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME

--- a/src/examples/standard-build-and-push.yml
+++ b/src/examples/standard-build-and-push.yml
@@ -1,8 +1,8 @@
 description: >
   A standard Docker workflow, where you are building an image with a
   Dockerfile in the root of your repository, naming the image to be the
-  same name as your repository, and then pushing to the default docker
-  registry (at docker.io)
+  same name as your repository, pushing to the default docker
+  registry (at docker.io), and then updating the image description
 
 usage:
   version: 2.1

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -29,6 +29,11 @@ parameters:
     default: Dockerfile
     description: Name of dockerfile to use, defaults to Dockerfile
 
+  readme:
+    type: string
+    default: README.md
+    description: Name of the file containing the image description to update, defaults to README.md
+
   path:
     type: string
     default: .
@@ -98,6 +103,11 @@ parameters:
     type: boolean
     default: true
 
+  update-description:
+    description: Update the image description on Docker Hub?
+    type: boolean
+    default: true
+
   docker-username:
     type: env_var_name
     default: DOCKER_LOGIN
@@ -160,3 +170,14 @@ steps:
             registry: <<parameters.registry>>
             image: <<parameters.image>>
             tag: <<parameters.tag>>
+
+  - when:
+      condition: <<parameters.update-description>>
+      steps:
+        - update:
+            readme: <<parameters.readme>>
+            path: <<parameters.path>>
+            registry: <<parameters.registry>>
+            image: <<parameters.image>>
+            docker-username: <<parameters.docker-username>>
+            docker-password: <<parameters.docker-password>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
This PR closes #46

### Description

This PR adds an `update` command which update's an image's description to the contents of `README.md` when publishing to Docker Hub. The publish job has been modified to run the update command as well.

I've also added parameters to provide a custom README file as well as disable updating the description. Currently, descriptions are updated by default.

I'm not sure of the best way to test these changes in CI, but I manually tested them and they appear to be functioning as intended.
