### PR TITLE
extract docker-compose version number for compare installed version

### DIFF
--- a/src/commands/install-docker-compose.yml
+++ b/src/commands/install-docker-compose.yml
@@ -53,6 +53,9 @@ steps:
           echo "Selected version of docker-compose is $DOCKER_COMPOSE_VERSION"
         fi
 
+        # extract docker-compose version number
+        DOCKER_COMPOSE_VERSION=`echo $DOCKER_COMPOSE_VERSION | grep -o -E "(\d+\.)+\d+"`
+
         # check if docker-compose needs to be installed
         if command -v docker-compose >> /dev/null 2>&1; then
           if docker-compose --version | grep "$DOCKER_COMPOSE_VERSION" >> /dev/null 2>&1; then


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] ~Examples have been added for any significant new features~
- [ ] ~README has been updated, if necessary~

### Motivation, issues

#49 

### Description

Version checking on install docker-compose was failed because docker-compose version naming conversion has changed to `vX.Y.Z` from `X.Y.Z`.
So I fix it.