### PR TITLE
fix: respect step-name parameter in build command [semver:patch]

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -81,7 +81,7 @@ steps:
       condition: <<parameters.cache_from>>
       steps:
         - run:
-            name: Docker build
+            name: <<parameters.step-name>>
             command: |
               echo "<<parameters.cache_from>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
                 echo "Pulling ${image}";
@@ -104,7 +104,7 @@ steps:
       condition: <<parameters.cache_from>>
       steps:
         - run:
-            name: Docker build
+            name: <<parameters.step-name>>
             command: |
               docker_tag_args=""
 


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions (N/A)
- [x] Examples have been added for any significant new features (N/A)
- [x] README has been updated, if necessary (N/A)

### Motivation, issues

Fixes #52.

### Description

Leverage `<<parameters.step-name>>` instead of hard-coded value.