### PR TITLE
Add commands for docker credentials store usage [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,9 +101,38 @@ jobs:
           images: cimg/base:stable,cimg/base:not_exists,cimg/go:stable
           ignore-docker-pull-error: true
 
+  test-credentials-store:
+    parameters:
+      executor:
+        type: executor
+      docker-username:
+        type: env_var_name
+      docker-password:
+        type: env_var_name
+    executor: <<parameters.executor>>
+
+    steps:
+      - docker/install-docker-credential-helper
+      - docker/configure-docker-credentials-store
+      - run:
+          name: Test login
+          command: |
+            LOGIN_RESULT=$(echo "$<<parameters.docker-password>>" \
+            | docker login -u "$<<parameters.docker-username>>" --password-stdin)
+            set -x
+            echo "$LOGIN_RESULT" | grep "Login Succeeded"
+            set +x
+            if echo "$LOGIN_RESULT" | grep -q "WARNING"; then
+            echo "Error - warning found in login result"
+            exit 1
+            fi
+
 promotion_requires: &promotion_requires
   [
     hadolint,
+    test-credentials-store-docker,
+    test-credentials-store-machine,
+    test-credentials-store-macos,
     publish-machine,
     publish-docker-cache,
     publish-docker-cache-not-found,
@@ -163,6 +192,25 @@ workflows:
           trusted-registries: docker.io,my-company.com:5000
           dockerfiles: test.Dockerfile,test2.Dockerfile
 
+      # login with credentials store
+      - test-credentials-store:
+          name: test-credentials-store-docker
+          executor: docker/docker
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+
+      - test-credentials-store:
+          name: test-credentials-store-machine
+          executor: orb-tools/machine
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+
+      - test-credentials-store:
+          name: test-credentials-store-macos
+          executor: orb-tools/macos
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+
       # build/publish
       - docker/publish:
           name: publish-machine
@@ -172,6 +220,9 @@ workflows:
           tag: $CIRCLE_BUILD_NUM-$CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
+          pre-steps:
+            - docker/install-docker-credential-helper
+            - docker/configure-docker-credentials-store
 
       - docker/publish:
           name: publish-docker
@@ -197,6 +248,9 @@ workflows:
           cache_from: circlecipublic/docker-orb-test:$CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
+          pre-steps:
+            - docker/install-docker-credential-helper
+            - docker/configure-docker-credentials-store
 
       - docker/publish:
           name: publish-docker-cache-not-found

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,10 @@ jobs:
     parameters:
       executor:
         type: executor
+      helper-name:
+        type: enum
+        enum: ["", "pass", "osxkeychain"]
+        default: ""
       docker-username:
         type: env_var_name
       docker-password:
@@ -130,8 +134,10 @@ jobs:
     executor: <<parameters.executor>>
 
     steps:
-      - docker/install-docker-credential-helper
-      - docker/configure-docker-credentials-store
+      - docker/install-docker-credential-helper:
+          helper-name: <<parameters.helper-name>>
+      - docker/configure-docker-credentials-store:
+          helper-name: <<parameters.helper-name>>
       - run:
           name: Test login
           command: |
@@ -245,6 +251,7 @@ workflows:
           name: test-credentials-store-docker
           executor: docker/docker
           context: orb-publishing
+          helper-name: pass
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,10 +225,9 @@ workflows:
           tag: $CIRCLE_BUILD_NUM-$CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
+          use-docker-credentials-store: true
           pre-steps:
-            - docker/install-docker-credential-helper
-            - docker/configure-docker-credentials-store
-            # Test that it's OK to invoke them twice
+            # Test that it's OK to invoke the commands twice
             - docker/install-docker-credential-helper
             - docker/configure-docker-credentials-store
 
@@ -242,6 +241,7 @@ workflows:
           tag: $CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
+          use-docker-credentials-store: true
 
       - docker/publish:
           name: publish-docker-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,18 +196,21 @@ workflows:
       - test-credentials-store:
           name: test-credentials-store-docker
           executor: docker/docker
+          context: orb-publishing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
 
       - test-credentials-store:
           name: test-credentials-store-machine
           executor: orb-tools/machine
+          context: orb-publishing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
 
       - test-credentials-store:
           name: test-credentials-store-macos
           executor: orb-tools/macos
+          context: orb-publishing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,9 @@ workflows:
           pre-steps:
             - docker/install-docker-credential-helper
             - docker/configure-docker-credentials-store
+            # Test that it's OK to invoke them twice
+            - docker/install-docker-credential-helper
+            - docker/configure-docker-credentials-store
 
       - docker/publish:
           name: publish-docker
@@ -254,8 +257,10 @@ workflows:
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
           pre-steps:
-            - docker/install-docker-credential-helper
-            - docker/configure-docker-credentials-store
+            - docker/install-docker-credential-helper:
+                release-tag: v0.6.3
+            - docker/configure-docker-credentials-store:
+                helper-name: pass
 
       - docker/publish:
           name: publish-docker-cache-not-found

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,8 @@ workflows:
           context: orb-publishing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
+          pre-steps:
+            - docker/install-docker
 
       # build/publish
       - docker/publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
         type: env_var_name
       use-docker-credentials-store:
         type: boolean
-      executor: <<parameters.executor>>
+    executor: <<parameters.executor>>
 
     steps:
       - docker/check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,24 @@ jobs:
           images: cimg/base:stable,cimg/base:not_exists,cimg/go:stable
           ignore-docker-pull-error: true
 
+  test-check-command:
+    parameters:
+      executor:
+        type: executor
+      docker-username:
+        type: env_var_name
+      docker-password:
+        type: env_var_name
+      use-docker-credentials-store:
+        type: boolean
+      executor: <<parameters.executor>>
+
+    steps:
+      - docker/check:
+          docker-username: <<parameters.docker-username>>
+          docker-password: <<parameters.docker-password>>
+          use-docker-credentials-store: <<parameters.use-docker-credentials-store>>
+
   test-credentials-store:
     parameters:
       executor:
@@ -130,6 +148,9 @@ jobs:
 promotion_requires: &promotion_requires
   [
     hadolint,
+    test-check-command-docker,
+    test-check-command-machine,
+    test-check-command-macos,
     test-credentials-store-docker,
     test-credentials-store-machine,
     test-credentials-store-macos,
@@ -192,7 +213,34 @@ workflows:
           trusted-registries: docker.io,my-company.com:5000
           dockerfiles: test.Dockerfile,test2.Dockerfile
 
-      # login with credentials store
+      # check command
+      - test-check-command:
+          name: test-check-command-docker
+          executor: docker/docker
+          context: orb-publishing
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          use-docker-credentials-store: false
+
+      - test-check-command:
+          name: test-check-command-machine
+          executor: orb-tools/machine
+          context: orb-publishing
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          use-docker-credentials-store: true
+
+      - test-check-command:
+          name: test-check-command-macos
+          executor: orb-tools/macos
+          context: orb-publishing
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          use-docker-credentials-store: true
+          pre-steps:
+            - docker/install-docker
+
+      # login with credentials store does not result in warning
       - test-credentials-store:
           name: test-credentials-store-docker
           executor: docker/docker

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,9 +2,12 @@ version: 2.1
 
 description: >
   Quickly and easily install/configure/use Docker, `dockerize`, and
-  `docker-compose` in any CircleCI job. See this orb's source:
-  https://github.com/CircleCI-Public/docker-orb
+  `docker-compose` in any CircleCI job.
+
+display:
+  source_url: https://github.com/CircleCI-Public/docker-orb
 
 orbs:
   bt: circleci/build-tools@2.6.3
+  jq: circleci/jq@1.9
   orb-tools: circleci/orb-tools@8.8.0

--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -21,12 +21,25 @@ parameters:
     description: >
       Name of environment variable storing your Docker password
 
+  use-docker-credentials-store:
+    type: boolean
+    default: false
+    description: >
+      Configure Docker to use a credentials store.
+      This option is only supported on Ubuntu/Debian/macOS platforms.
+
 steps:
   - orb-tools/check-env-var-param:
       param: <<parameters.docker-username>>
 
   - orb-tools/check-env-var-param:
       param: <<parameters.docker-password>>
+
+  - when:
+      condition: <<parameters.use-docker-credentials-store>>
+      steps:
+        - install-docker-credential-helper
+        - configure-docker-credentials-store
 
   - run:
       name: Docker login

--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -31,6 +31,6 @@ steps:
   - run:
       name: Docker login
       command: |
-        docker login \
-          -u "$<<parameters.docker-username>>" -p "$<<parameters.docker-password>>" \
-          <<parameters.registry>>
+        echo "$<<parameters.docker-password>>" \
+          | docker login -u "$<<parameters.docker-username>>" \
+              --password-stdin <<parameters.registry>>

--- a/src/commands/configure-docker-credentials-store.yml
+++ b/src/commands/configure-docker-credentials-store.yml
@@ -1,0 +1,44 @@
+description: >
+  Configure a credentials store for docker to use.
+  See: https://docs.docker.com/engine/reference/commandline/login/#credentials-store#credentials-store
+  Supported platforms: Linux and macOS.
+
+parameters:
+  helper-name:
+    description: >
+      Name of the credential helper to be used, e.g. "pass".
+      If left blank, the orb will attempt to choose one based on the platform.
+    type: string
+    default: ""
+  docker-config-path:
+    description: >
+      Path to the Docker CLI config file.
+      See: https://docs.docker.com/engine/reference/commandline/cli/#configjson-properties#configjson-properties
+    type: string
+    default: $HOME/.docker/config.json
+
+steps:
+  - jq/install
+  - run:
+      name: Configure Docker credentials store
+      command: |
+        HELPER_NAME="<<parameters.helper-name>>"
+        if [ -z "${HELPER_NAME}" ]; then
+          if [ -n "$(uname | grep "Darwin")" ]; then
+            HELPER_NAME="osxkeychain"
+          else
+            HELPER_NAME="pass"
+          fi
+        fi
+
+        if [ ! -f "<<parameters.docker-config-path>>" ]; then
+          echo "<<parameters.docker-config-path>> does not exist; initializing it.."
+          mkdir -p $(dirname <<parameters.docker-config-path>>)
+          echo "{}" > <<parameters.docker-config-path>>
+        fi
+
+        cat <<parameters.docker-config-path>> \
+          | jq --arg credsStore "$HELPER_NAME" '. + {credsStore: $credsStore}' \
+          > /tmp/docker-config-credsstore-update.json
+        cat /tmp/docker-config-credsstore-update.json > <<parameters.docker-config-path>>
+        rm /tmp/docker-config-credsstore-update.json

--- a/src/commands/configure-docker-credentials-store.yml
+++ b/src/commands/configure-docker-credentials-store.yml
@@ -8,7 +8,8 @@ parameters:
     description: >
       Name of the credential helper to be used, e.g. "pass".
       If left blank, the orb will attempt to choose one based on the platform.
-    type: string
+    type: enum
+    enum: ["", "pass", "osxkeychain"]
     default: ""
   docker-config-path:
     description: >

--- a/src/commands/configure-docker-credentials-store.yml
+++ b/src/commands/configure-docker-credentials-store.yml
@@ -13,7 +13,6 @@ parameters:
   docker-config-path:
     description: >
       Path to the Docker CLI config file.
-      See: https://docs.docker.com/engine/reference/commandline/cli/#configjson-properties#configjson-properties
     type: string
     default: $HOME/.docker/config.json
 

--- a/src/commands/install-docker-credential-helper.yml
+++ b/src/commands/install-docker-credential-helper.yml
@@ -1,0 +1,80 @@
+description: >
+  Install a credential helper for Docker, automatically chosen
+  based on platform detection.
+  See: https://docs.docker.com/engine/reference/commandline/login/#credentials-store#credential-helpers
+  Supported platforms: Ubuntu/Debian and macOS.
+parameters:
+  release-tag:
+    description: >
+      Use this to specify a tag to select which published release of the docker credential helper,
+      as listed on https://github.com/docker/docker-credential-helpers/releases,
+      to install. If no value is specified, the latest release will be installed.
+      Note: Pre or alpha releases cannot be specified.
+    type: string
+    default: ""
+
+steps:
+  - run:
+      name: Install Docker credential helper
+      command: |
+        SUDO=""
+        if [ $(id -u) -ne 0 ] && which sudo > /dev/null 2>&1 ; then
+          SUDO="sudo"
+        fi
+
+        GPG_TEMPLATE=$(mktemp gpg_template.XXXXXX)
+        cat > $GPG_TEMPLATE \<<-EOF
+        Key-Type: RSA
+        Key-Length: 2048
+        Name-Real: CircleCI Orb User
+        Name-Email: circleci-orbs@circleci.com
+        Expire-Date: 0
+        %no-protection
+        %no-ask-passphrase
+        %commit
+        EOF
+
+        if [ -n "$(uname | grep "Darwin")" ]; then
+          HELPER_FILENAME="docker-credential-osxkeychain"
+        else
+          HELPER_FILENAME="docker-credential-pass"
+          # Install pass which is needed for docker-credential-pass to work
+          $SUDO apt-get update --yes && $SUDO apt-get install gnupg2 pass --yes
+
+          # Initialize pass with a gpg key
+          gpg2 --batch --gen-key "$GPG_TEMPLATE"
+
+          FINGERPRINT_STRING=$(gpg2 \
+            --list-keys --with-fingerprint --with-colons \
+            circleci-orbs@circleci.com | \
+            grep fpr)
+          # use colon delimiters to separate fingerprint
+          arrFINGERPRINT=(${FINGERPRINT_STRING//:/ })
+          FINGERPRINT=${arrFINGERPRINT[-1]}
+          pass init $FINGERPRINT
+        fi
+
+        if which "$HELPER_FILENAME" > /dev/null 2>&1; then
+          echo "$HELPER_FILENAME is already installed"
+          exit 0
+        fi
+
+        echo "Downloading credential helper $HELPER_FILENAME"
+        BIN_PATH="/usr/local/bin"
+        mkdir -p "$BIN_PATH"
+        RELEASE_TAG="<< parameters.release-tag >>"
+        RELEASE_URL="https://api.github.com/repos/docker/docker-credential-helpers/releases/latest"
+        if [ -n "${RELEASE_TAG}" ]; then
+          RELEASE_URL="https://api.github.com/repos/docker/docker-credential-helpers/releases/tags/${RELEASE_TAG}"
+        fi
+        DOWNLOAD_URL=$(curl -s --retry 5 "${RELEASE_URL}" \
+            | grep "${HELPER_FILENAME}" | awk '/browser_download_url/ {print $2}' | sed 's/"//g')
+        echo "Downloading from url: $DOWNLOAD_URL"
+        curl -L -o "${HELPER_FILENAME}_archive" "$DOWNLOAD_URL"
+        tar xvf "./${HELPER_FILENAME}_archive"
+        chmod +x "./$HELPER_FILENAME"
+
+        $SUDO mv "./$HELPER_FILENAME" "$BIN_PATH/$HELPER_FILENAME"
+        "$BIN_PATH/$HELPER_FILENAME" version
+        rm "./${HELPER_FILENAME}_archive"
+        rm "$GPG_TEMPLATE"

--- a/src/commands/install-docker-credential-helper.yml
+++ b/src/commands/install-docker-credential-helper.yml
@@ -17,11 +17,23 @@ steps:
   - run:
       name: Install Docker credential helper
       command: |
+        if [ -n "$(uname | grep "Darwin")" ]; then
+          HELPER_FILENAME="docker-credential-osxkeychain"
+        else
+          HELPER_FILENAME="docker-credential-pass"
+        fi
+
+        if which "$HELPER_FILENAME" > /dev/null 2>&1; then
+          echo "$HELPER_FILENAME is already installed"
+          exit 0
+        fi
+
         SUDO=""
         if [ $(id -u) -ne 0 ] && which sudo > /dev/null 2>&1 ; then
           SUDO="sudo"
         fi
 
+        # Create heredoc template here due to tab indentation issue
         GPG_TEMPLATE=$(mktemp gpg_template.XXXXXX)
         cat > $GPG_TEMPLATE \<<-EOF
         Key-Type: RSA
@@ -34,10 +46,7 @@ steps:
         %commit
         EOF
 
-        if [ -n "$(uname | grep "Darwin")" ]; then
-          HELPER_FILENAME="docker-credential-osxkeychain"
-        else
-          HELPER_FILENAME="docker-credential-pass"
+        if [ "$HELPER_FILENAME" = "docker-credential-pass" ]; then
           # Install pass which is needed for docker-credential-pass to work
           $SUDO apt-get update --yes && $SUDO apt-get install gnupg2 pass --yes
 
@@ -53,11 +62,7 @@ steps:
           FINGERPRINT=${arrFINGERPRINT[-1]}
           pass init $FINGERPRINT
         fi
-
-        if which "$HELPER_FILENAME" > /dev/null 2>&1; then
-          echo "$HELPER_FILENAME is already installed"
-          exit 0
-        fi
+        rm "$GPG_TEMPLATE"
 
         echo "Downloading credential helper $HELPER_FILENAME"
         BIN_PATH="/usr/local/bin"
@@ -77,4 +82,3 @@ steps:
         $SUDO mv "./$HELPER_FILENAME" "$BIN_PATH/$HELPER_FILENAME"
         "$BIN_PATH/$HELPER_FILENAME" version
         rm "./${HELPER_FILENAME}_archive"
-        rm "$GPG_TEMPLATE"

--- a/src/commands/install-docker-credential-helper.yml
+++ b/src/commands/install-docker-credential-helper.yml
@@ -4,6 +4,13 @@ description: >
   See: https://docs.docker.com/engine/reference/commandline/login/#credentials-store#credential-helpers
   Supported platforms: Ubuntu/Debian and macOS.
 parameters:
+  helper-name:
+    description: >
+      Name of the credential helper to be installed, e.g. "pass".
+      If left blank, the orb will attempt to choose one based on the platform.
+    type: enum
+    enum: ["", "pass", "osxkeychain"]
+    default: ""
   release-tag:
     description: >
       Use this to specify a tag to select which published release of the docker credential helper,
@@ -17,11 +24,16 @@ steps:
   - run:
       name: Install Docker credential helper
       command: |
-        if [ -n "$(uname | grep "Darwin")" ]; then
-          HELPER_FILENAME="docker-credential-osxkeychain"
-        else
-          HELPER_FILENAME="docker-credential-pass"
+        HELPER_NAME="<<parameters.helper-name>>"
+        if [ -z "${HELPER_NAME}" ]; then
+          if [ -n "$(uname | grep "Darwin")" ]; then
+            HELPER_NAME="osxkeychain"
+          else
+            HELPER_NAME="pass"
+          fi
         fi
+
+        HELPER_FILENAME="docker-credential-${HELPER_NAME}"
 
         if which "$HELPER_FILENAME" > /dev/null 2>&1; then
           echo "$HELPER_FILENAME is already installed"

--- a/src/examples/login-with-credentials-store.yml
+++ b/src/examples/login-with-credentials-store.yml
@@ -1,0 +1,18 @@
+description: >
+  This demonstrates performing docker login with a credentials store
+  configured, and then building an image with a Dockerfile in the root of
+  your repository, naming the image to be the same name as your repository,
+  and then pushing to the default docker registry (at docker.io)
+
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  workflows:
+    build-and-publish-docker-image:
+      jobs:
+        - docker/publish:
+            image:  $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+            use-docker-credentials-store: true

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -132,18 +132,13 @@ steps:
             docker_layer_caching: <<parameters.remote-docker-dlc>>
 
   - when:
-      condition: <<parameters.use-docker-credentials-store>>
-      steps:
-        - install-docker-credential-helper
-        - configure-docker-credentials-store
-
-  - when:
       condition: <<parameters.deploy>>
       steps:
         - check:
             registry: <<parameters.registry>>
             docker-username: <<parameters.docker-username>>
             docker-password: <<parameters.docker-password>>
+            use-docker-credentials-store: <<parameters.use-docker-credentials-store>>
 
   - when:
       name: Run before_build lifecycle hook steps

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -64,6 +64,13 @@ parameters:
     description: >
       Name of registry to use, defaults to docker.io
 
+  use-docker-credentials-store:
+    type: boolean
+    default: false
+    description: >
+      Configure Docker to use a credentials store.
+      This option is only supported on Ubuntu/Debian platforms.
+
   extra_build_args:
     type: string
     default: ""
@@ -123,6 +130,12 @@ steps:
       steps:
         - setup_remote_docker:
             docker_layer_caching: <<parameters.remote-docker-dlc>>
+
+  - when:
+      condition: <<parameters.use-docker-credentials-store>>
+      steps:
+        - install-docker-credential-helper
+        - configure-docker-credentials-store
 
   - when:
       condition: <<parameters.deploy>>


### PR DESCRIPTION
## Issue
When `docker login` is done without a credentials store configured, the command returns a warning:

```
docker: WARNING! Your password will be stored unencrypted in /home/circleci/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store
```

This warning has high impact for Azure ACR usage. In the latest version of the Azure client, the `az acr login` command returns an error if a credentials store is not used: (See: https://github.com/CircleCI-Public/azure-acr-orb/issues/11)

```
#!/bin/bash -eo pipefail
az acr login --name azureacrorb
Login Succeeded
docker: WARNING! Your password will be stored unencrypted in /home/********/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Exited with code exit status 1
```

## Changes

### New commands
In this PR, we add 2 new commands, `install-docker-credential-helper` and `configure-docker-credentials-store`  that will make it easier to use a credentials store for `docker login`. 

### Existing commands/jobs
- Backwards-compatible change to the `check` command, to to use `--password-stdin` during docker login, to eliminate the `WARNING! Using --password via the CLI is insecure. Use --password-stdin.` warning, as well as to add a new `use-docker-credentials-store` parameter (defaults to `false`).
- Add `use-docker-credentials-store` parameter to the `publish` job

