### PR TITLE
Fix bug when multiple tags and digest path present

### DIFF
--- a/src/commands/push.yml
+++ b/src/commands/push.yml
@@ -37,5 +37,6 @@ steps:
 
         if [ -n "<<parameters.digest-path>>" ]; then
           mkdir -p "$(dirname <<parameters.digest-path>>)"
-          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> > "<<parameters.digest-path>>"
+          IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry>>/<< parameters.image>>:"${DOCKER_TAGS[0]}" > "<<parameters.digest-path>>"
         fi


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

When providing both multiple tags and a digest path in `docker/push`,
the digest lookup would previously fail with `invalid reference format`
as it would append all the tags. 

[Here is an example of this bug](https://app.circleci.com/pipelines/github/agilepathway/cimg-gauge/109/workflows/a8534681-9984-4de8-8711-6c446bf1ec96/jobs/294) manifesting itself, caused by having [both multiple tags and a digest path specified](https://github.com/agilepathway/cimg-gauge/commit/6de0a4bcea736f8347ea9b01bec2b42b1ff66882), e.g:

```
- docker/push:
    digest-path: /tmp/digest
    image: agilepathway/cimg-gauge-multiple-tags
    tag: 'tag1,tag2'
```



### Description

Fix bug in `docker/push` command when specifying both of the following together:

1. multiple tags
2. digest path

Fix by now always using the first provided tag for the digest lookup.

### Testing

I manually tested the following scenarios by [forking](https://github.com/agilepathway/docker-orb) the Docker Orb, [deploying the fix](https://app.circleci.com/pipelines/github/agilepathway/docker-orb/29/workflows/3090a22b-3ffb-4a86-b4ce-7f579e1b8f48) and then testing against it:

1. [Multiple tags with digest path](https://app.circleci.com/pipelines/github/agilepathway/cimg-gauge/116/workflows/986a27c8-79a3-4e2d-9185-e29cbc20209b/jobs/303)
2. [Single tag with digest path](https://app.circleci.com/pipelines/github/agilepathway/cimg-gauge/114/workflows/9f63e9eb-57d7-44fe-90c9-4e5ff14d18f9/jobs/301)
3. [Default tag (i.e. no tag parameter) with digest path](https://app.circleci.com/pipelines/github/agilepathway/cimg-gauge/117/workflows/3e09c2b4-9772-4323-9779-08b8ebe8ce8e/jobs/304)
