### PR TITLE
[semver:minor] Use colon delimiters in hadolint dockerfiles parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ workflows:
           name: hadolint
           ignore-rules: DL4005,DL3008,DL3009,DL3015
           trusted-registries: docker.io,my-company.com:5000
-          dockerfiles: test.Dockerfile,test2.Dockerfile
+          dockerfiles: test.Dockerfile:test2.Dockerfile
 
       # check command
       - test-check-command:

--- a/src/jobs/hadolint.yml
+++ b/src/jobs/hadolint.yml
@@ -29,8 +29,8 @@ parameters:
       Relative or absolute path, including name, to Dockerfile(s) to be
       linted, e.g., `~/project/app/deploy.Dockerfile`, defaults to a
       Dockerfile named `Dockerfile` in the working directory. To lint
-      multiple Dockerfiles, pass a comma-separated string, e.g.,
-      `~/project/app/deploy.Dockerfile,~/project/app/test.Dockerfile`.
+      multiple Dockerfiles, pass a colon-separated string, e.g.,
+      `~/project/app/deploy.Dockerfile:~/project/app/test.Dockerfile`.
 
   ignore-rules:
     type: string
@@ -82,8 +82,8 @@ steps:
 
         DOCKERFILES=<<parameters.dockerfiles>>
 
-        # use comma delimiters to create array
-        arrDOCKERFILES=(${DOCKERFILES//,/ })
+        # use colon delimiters to create array
+        arrDOCKERFILES=(${DOCKERFILES//:/ })
         let END=${#arrDOCKERFILES[@]}
 
         for ((i=0;i<END;i++)); do


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

When I used hadolint job with multiple tilde-prefixed Dockerfile paths as the dockerfiles parameter, _No such file or directory_ error occurred.

```
DOCKERFILES=~/project/frontend/Dockerfile,~/project/worker/Dockerfile
...
Running hadolint with the following options...

Success! /root/project/frontend/Dockerfile linted; no issues found
hadolint: ~/project/worker/Dockerfile: openBinaryFile: does not exist (No such file or directory)
```

According to [the bash manual](https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html), _Each variable assignment is checked for unquoted tilde-prefixes immediately following a ‘:’ or the first ‘=’_. So, we should use colons instead of commas.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Change comma delimiters to colons in hadolint job's dockerfiles parameter.