### PR TITLE
Revert "Fix bug when multiple tags and digest path present" (#71) [skip ci]

### DIFF
--- a/src/commands/push.yml
+++ b/src/commands/push.yml
@@ -37,6 +37,5 @@ steps:
 
         if [ -n "<<parameters.digest-path>>" ]; then
           mkdir -p "$(dirname <<parameters.digest-path>>)"
-          IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
-          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry>>/<< parameters.image>>:"${DOCKER_TAGS[0]}" > "<<parameters.digest-path>>"
+          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry>>/<< parameters.image>>:<<parameters.tag>> > "<<parameters.digest-path>>"
         fi


### PR DESCRIPTION
Reverts CircleCI-Public/docker-orb#62