### PR TITLE
Add no_output_timeout parameter for docker build timeout and update python install on alpine [semver:minor]

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -76,14 +76,19 @@ parameters:
       `attach_workspace` attached location - where to mount folder/files that were `persist_to_workspace` in a previous step.
       https://circleci.com/docs/2.0/configuration-reference/#attach_workspace
 
-
-
   docker-context:
     type: string
     default: .
     description: >
       Path to the directory containing your build context,
       defaults to . (working directory)
+
+  no_output_timeout:
+    type: string
+    default: "10m"
+    description: >
+      Pass through a default timeout if your Docker build does not output
+      anything for more than 10 minutes.
 
 steps:
   - when:
@@ -105,6 +110,7 @@ steps:
       steps:
         - run:
             name: <<parameters.step-name>>
+            no_output_timeout: << parameters.no_output_timeout >>
             command: |
               echo "<<parameters.cache_from>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
                 echo "Pulling ${image}";
@@ -128,6 +134,7 @@ steps:
       steps:
         - run:
             name: <<parameters.step-name>>
+            no_output_timeout: << parameters.no_output_timeout >>
             command: |
               docker_tag_args=""
 

--- a/src/commands/install-docker-compose.yml
+++ b/src/commands/install-docker-compose.yml
@@ -46,8 +46,8 @@ steps:
 
         # docker-compose binary won't run on alpine, install via pip
         if cat /etc/issue | grep Alpine >> /dev/null 2>&1; then
-          $SUDO apk add gcc libc-dev libffi-dev openssl-dev make python-dev py-pip
-          $SUDO pip install docker-compose=="$DOCKER_COMPOSE_VERSION"
+          $SUDO apk add gcc libc-dev libffi-dev openssl-dev make python3-dev
+          python3 -m pip install docker-compose=="$DOCKER_COMPOSE_VERSION"
         else
           # get binary/shasum download URL for specified version
           if uname -a | grep Darwin >> /dev/null 2>&1; then

--- a/src/commands/install-docker-compose.yml
+++ b/src/commands/install-docker-compose.yml
@@ -46,8 +46,9 @@ steps:
 
         # docker-compose binary won't run on alpine, install via pip
         if cat /etc/issue | grep Alpine >> /dev/null 2>&1; then
-          $SUDO apk add gcc libc-dev libffi-dev openssl-dev make python3-dev
-          python3 -m pip install docker-compose=="$DOCKER_COMPOSE_VERSION"
+          $SUDO apk update
+          $SUDO apk add gcc libc-dev libffi-dev openssl-dev make python3-dev py-pip
+          $SUDO python3 -m pip install docker-compose=="$DOCKER_COMPOSE_VERSION"
         else
           # get binary/shasum download URL for specified version
           if uname -a | grep Darwin >> /dev/null 2>&1; then


### PR DESCRIPTION
### Checklist

   - [x] All new jobs, commands, executors, parameters have descriptions
   - [x] Examples have been added for any significant new features
   - [x] README has been updated, if necessary

### Motivation, issues

Part of https://github.com/CircleCI-Public/gcp-gcr-orb/issues/41

### Description

Add no_output_timeout param for Docker image build and update python install on alpine by switching to python3.
