### PR TITLE
[semver:minor] Allow hadolint image tag and resource class to be passed in the `hadolint` job

### DIFF
--- a/src/examples/hadolint.yml
+++ b/src/examples/hadolint.yml
@@ -14,3 +14,5 @@ usage:
             ignore-rules: DL4005,DL3008
             trusted-registries: docker.io,my-company.com:5000
             dockerfiles: path/to/Dockerfile
+            hadolint-tag: 2.2.0-debian
+            executor-class: medium

--- a/src/jobs/hadolint.yml
+++ b/src/jobs/hadolint.yml
@@ -47,6 +47,25 @@ parameters:
       `docker.io,my-company.com:5000`); if set, return an error if
       Dockerfiles use any images from registries not included in this list
 
+  hadolint-tag:
+    type: string
+    default: latest-debian
+    description: >
+      Specific Hadolint image (make sure to use a `debian` tag, otherwise image
+      will not be usable on CircleCI):
+      https://hub.docker.com/r/hadolint/hadolint/tags
+    
+  executor-class:
+    type: enum
+    default: small
+    description: Resource class to use for the hadolint executor
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+
 executor: hadolint
 
 steps:

--- a/src/jobs/hadolint.yml
+++ b/src/jobs/hadolint.yml
@@ -66,7 +66,10 @@ parameters:
       - large
       - xlarge
 
-executor: hadolint
+executor:
+  name: hadolint
+  tag: <<parameters.hadolint-tag>>
+  resource-class: <<parameters.executor-class>>
 
 steps:
   - bt/install-ci-tools

--- a/src/jobs/hadolint.yml
+++ b/src/jobs/hadolint.yml
@@ -54,7 +54,7 @@ parameters:
       Specific Hadolint image (make sure to use a `debian` tag, otherwise image
       will not be usable on CircleCI):
       https://hub.docker.com/r/hadolint/hadolint/tags
-    
+
   executor-class:
     type: enum
     default: small


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

When using the orb's [`hadolint` job](https://circleci.com/developer/orbs/orb/circleci/docker#jobs-hadolint), it's not currently possible to specify the `hadolint` image tag or the `resource_class` to use, as defined in the orb's [`hadolint` executor](https://circleci.com/developer/orbs/orb/circleci/docker#executors-hadolint).

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Add pass-through parameters `hadolint-tag` and `executor-class` to the `hadolint` job so users can override the `hadolint` executor default parameters.

This pull-request resolves #80.