### PR TITLE
Patch pr/81 [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ workflows:
       - test:
           name: latest-alpine
           executor: orb-tools/alpine
-          pre-steps: [run: apk add gnupg]
+          pre-steps: [run: pip install --upgrade pip, run: apk add gnupg]
       - test:
           name: older-alpine
           executor: orb-tools/alpine
@@ -377,12 +377,12 @@ workflows:
           docker-compose-version: 1.17.1
           dockerize-version: v0.4.0
           goss-version: v0.3.2
-          pre-steps: [run: apk add gnupg]
+          pre-steps: [run: pip install --upgrade pip, run: apk add gnupg]
       - test:
           name: latest-alpine-altogether
           executor: orb-tools/alpine
           test-all-in-one-command: true
-          pre-steps: [run: apk add gnupg]
+          pre-steps: [run: pip install --upgrade pip, run: apk add gnupg]
       - test:
           name: older-alpine-altogether
           executor: orb-tools/alpine
@@ -391,7 +391,7 @@ workflows:
           docker-compose-version: 1.17.1
           dockerize-version: v0.4.0
           goss-version: v0.3.3
-          pre-steps: [run: apk add gnupg]
+          pre-steps: [run: pip install --upgrade pip, run: apk add gnupg]
       # machine
       - test:
           name: latest-machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,6 +516,7 @@ workflows:
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/docker
           context: orb-publisher
+          add-pr-comment: false
           fail-if-semver-not-indicated: true
           publish-version-tag: false
           requires: *promotion_requires

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
       - setup_remote_docker
       - docker/build:
           dockerfile: test.Dockerfile
-          image: circlecipublic/docker-orb-test
+          image: cpeorbtesting/docker-orb-test
           tag: $CIRCLE_BUILD_NUM-$CIRCLE_SHA1
           attach-at: "./"
       - run:
@@ -236,11 +236,11 @@ workflows:
           requires: [orb-tools/lint]
       - orb-tools/publish-dev:
           orb-name: circleci/docker
-          context: orb-publishing
+          context: orb-publisher
           requires: [orb-tools/pack]
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
-          context: orb-publishing
+          context: orb-publisher
           requires: [orb-tools/publish-dev]
 
   integration-tests_prod-release:
@@ -256,21 +256,21 @@ workflows:
       - test-check-command:
           name: test-check-command-docker
           executor: docker/docker
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
           use-docker-credentials-store: false
       - test-check-command:
           name: test-check-command-machine
           executor: orb-tools/machine
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
           use-docker-credentials-store: true
       - test-check-command:
           name: test-check-command-macos
           executor: orb-tools/macos
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
           use-docker-credentials-store: true
@@ -280,20 +280,20 @@ workflows:
       - test-credentials-store:
           name: test-credentials-store-docker
           executor: docker/docker
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           helper-name: pass
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
       - test-credentials-store:
           name: test-credentials-store-machine
           executor: orb-tools/machine
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
       - test-credentials-store:
           name: test-credentials-store-macos
           executor: orb-tools/macos
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
           pre-steps:
@@ -301,9 +301,9 @@ workflows:
       # build/publish
       - docker/publish:
           name: publish-machine
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           dockerfile: test.Dockerfile
-          image: circlecipublic/docker-orb-test
+          image: cpeorbtesting/docker-orb-test
           tag: $CIRCLE_BUILD_NUM-$CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
@@ -315,10 +315,10 @@ workflows:
       - docker/publish:
           name: publish-docker
           executor: docker/docker
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           use-remote-docker: true
           dockerfile: test.Dockerfile
-          image: circlecipublic/docker-orb-test
+          image: cpeorbtesting/docker-orb-test
           tag: $CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
@@ -328,12 +328,12 @@ workflows:
           requires:
             - publish-docker
           executor: docker/docker
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           use-remote-docker: true
           dockerfile: test.Dockerfile
-          image: circlecipublic/docker-orb-test
+          image: cpeorbtesting/docker-orb-test
           tag: $CIRCLE_SHA1
-          cache_from: circlecipublic/docker-orb-test:$CIRCLE_SHA1
+          cache_from: cpeorbtesting/docker-orb-test:$CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
           pre-steps:
@@ -344,23 +344,23 @@ workflows:
       - docker/publish:
           name: publish-docker-cache-not-found
           executor: docker/docker
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           use-remote-docker: true
           dockerfile: test.Dockerfile
-          image: circlecipublic/docker-orb-test
+          image: cpeorbtesting/docker-orb-test
           tag: $CIRCLE_SHA1-2
-          cache_from: circlecipublic/docker-orb-test:not-exists
+          cache_from: cpeorbtesting/docker-orb-test:not-exists
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
       - docker/publish:
           name: publish-docker-update-description
           executor: docker/docker
-          context: orb-publishing
+          context: CPE-orb-docker-testing
           use-remote-docker: true
           dockerfile: test.Dockerfile
-          image: circlecipublic/docker-orb-test
+          image: cpeorbtesting/docker-orb-test
           tag: $CIRCLE_SHA1
-          cache_from: circlecipublic/docker-orb-test:$CIRCLE_SHA1
+          cache_from: cpeorbtesting/docker-orb-test:$CIRCLE_SHA1
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
           update-description: true
@@ -515,10 +515,7 @@ workflows:
             - test-create-workspace
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/docker
-          context: orb-publishing
-          add-pr-comment: true
-          bot-token-variable: GHI_TOKEN
-          bot-user: cpe-bot
+          context: orb-publisher
           fail-if-semver-not-indicated: true
           publish-version-tag: false
           requires: *promotion_requires

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,6 @@ parameters:
     type: string
     default: "dev:alpha"
 
-executors:
-  alpine:
-    docker:
-      - image: alpine:latest
-
 jobs:
   test:
     parameters:
@@ -373,11 +368,11 @@ workflows:
       # alpine
       - test:
           name: latest-alpine
-          executor: alpine
+          executor: orb-tools/alpine
           pre-steps: [run: apk add gnupg]
       - test:
           name: older-alpine
-          executor: alpine
+          executor: orb-tools/alpine
           docker-version: v18.09.4
           docker-compose-version: 1.17.1
           dockerize-version: v0.4.0
@@ -385,12 +380,12 @@ workflows:
           pre-steps: [run: apk add gnupg]
       - test:
           name: latest-alpine-altogether
-          executor: alpine
+          executor: orb-tools/alpine
           test-all-in-one-command: true
           pre-steps: [run: apk add gnupg]
       - test:
           name: older-alpine-altogether
-          executor: alpine
+          executor: orb-tools/alpine
           test-all-in-one-command: true
           docker-version: v18.09.4
           docker-compose-version: 1.17.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,11 @@ parameters:
     type: string
     default: "dev:alpha"
 
+executors:
+  alpine:
+    docker:
+      - image: alpine:latest
+
 jobs:
   test:
     parameters:
@@ -368,30 +373,30 @@ workflows:
       # alpine
       - test:
           name: latest-alpine
-          executor: orb-tools/alpine
-          pre-steps: [run: pip install --upgrade pip, run: apk add gnupg]
+          executor: alpine
+          pre-steps: [run: apk add gnupg]
       - test:
           name: older-alpine
-          executor: orb-tools/alpine
+          executor: alpine
           docker-version: v18.09.4
           docker-compose-version: 1.17.1
           dockerize-version: v0.4.0
           goss-version: v0.3.2
-          pre-steps: [run: pip install --upgrade pip, run: apk add gnupg]
+          pre-steps: [run: apk add gnupg]
       - test:
           name: latest-alpine-altogether
-          executor: orb-tools/alpine
+          executor: alpine
           test-all-in-one-command: true
-          pre-steps: [run: pip install --upgrade pip, run: apk add gnupg]
+          pre-steps: [run: apk add gnupg]
       - test:
           name: older-alpine-altogether
-          executor: orb-tools/alpine
+          executor: alpine
           test-all-in-one-command: true
           docker-version: v18.09.4
           docker-compose-version: 1.17.1
           dockerize-version: v0.4.0
           goss-version: v0.3.3
-          pre-steps: [run: pip install --upgrade pip, run: apk add gnupg]
+          pre-steps: [run: apk add gnupg]
       # machine
       - test:
           name: latest-machine

--- a/src/commands/install-docker-compose.yml
+++ b/src/commands/install-docker-compose.yml
@@ -48,6 +48,7 @@ steps:
         if cat /etc/issue | grep Alpine >> /dev/null 2>&1; then
           $SUDO apk update
           $SUDO apk add gcc libc-dev libffi-dev openssl-dev make python3-dev py-pip
+          $SUDO pip install --upgrade pip
           $SUDO python3 -m pip install docker-compose=="$DOCKER_COMPOSE_VERSION"
         else
           # get binary/shasum download URL for specified version

--- a/src/commands/install-docker-compose.yml
+++ b/src/commands/install-docker-compose.yml
@@ -48,6 +48,7 @@ steps:
         if cat /etc/issue | grep Alpine >> /dev/null 2>&1; then
           $SUDO apk update
           $SUDO apk add gcc libc-dev libffi-dev openssl-dev make python3-dev py-pip
+          export CRYPTOGRAPHY_DONT_BUILD_RUST=1
           $SUDO pip install --upgrade pip
           $SUDO python3 -m pip install docker-compose=="$DOCKER_COMPOSE_VERSION"
         else

--- a/src/commands/update-description.yml
+++ b/src/commands/update-description.yml
@@ -51,5 +51,6 @@ steps:
         STATUS=$(curl -s -o /dev/null -w %{http_code} -X PATCH -H "$HEADER" --data-urlencode full_description@$DESCRIPTION $URL)
         if [ $STATUS -ne 200 ]; then
           echo "Could not update image description"
+          echo "Error code: $STATUS"
           exit 1
         fi

--- a/src/examples/hadolint.yml
+++ b/src/examples/hadolint.yml
@@ -14,3 +14,5 @@ usage:
             ignore-rules: DL4005,DL3008
             trusted-registries: docker.io,my-company.com:5000
             dockerfiles: path/to/Dockerfile
+            hadolint-tag: 2.2.0-debian
+            executor-class: medium

--- a/src/jobs/hadolint.yml
+++ b/src/jobs/hadolint.yml
@@ -47,6 +47,25 @@ parameters:
       `docker.io,my-company.com:5000`); if set, return an error if
       Dockerfiles use any images from registries not included in this list
 
+  hadolint-tag:
+    type: string
+    default: latest-debian
+    description: >
+      Specific Hadolint image (make sure to use a `debian` tag, otherwise image
+      will not be usable on CircleCI):
+      https://hub.docker.com/r/hadolint/hadolint/tags
+    
+  executor-class:
+    type: enum
+    default: small
+    description: Resource class to use for the hadolint executor
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+
 executor: hadolint
 
 steps:

--- a/src/jobs/hadolint.yml
+++ b/src/jobs/hadolint.yml
@@ -66,7 +66,10 @@ parameters:
       - large
       - xlarge
 
-executor: hadolint
+executor:
+  name: hadolint
+  tag: <<parameters.hadolint-tag>>
+  resource-class: <<parameters.executor-class>>
 
 steps:
   - bt/install-ci-tools

--- a/src/jobs/hadolint.yml
+++ b/src/jobs/hadolint.yml
@@ -54,7 +54,7 @@ parameters:
       Specific Hadolint image (make sure to use a `debian` tag, otherwise image
       will not be usable on CircleCI):
       https://hub.docker.com/r/hadolint/hadolint/tags
-    
+
   executor-class:
     type: enum
     default: small


### PR DESCRIPTION
extends pr #81 by @yaningo with required updates

Motivation, issues
When using the orb's hadolint job, it's not currently possible to specify the hadolint image tag or the resource_class to use, as defined in the orb's hadolint executor.

Description
Add pass-through parameters hadolint-tag and executor-class to the hadolint job so users can override the hadolint executor default parameters.

This pull-request resolves #80.

---

What this patch-pr provides to the original:
  - Replace Docker Auth
  - Fix Alpine tests by updating pip before installing Docker-Compose 
