### PR TITLE
[semver:minor] Split hadolint into own command.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ workflows:
       # hadolint
       - docker/hadolint:
           name: hadolint
-          ignore-rules: DL4005,DL3008,DL3009,DL3015
+          ignore-rules: DL4005,DL3008,DL3009,DL3015,DL3059
           trusted-registries: docker.io,my-company.com:5000
           dockerfiles: test.Dockerfile:test2.Dockerfile
       # check command

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,6 @@ jobs:
 
     steps:
       - checkout
-      - build-tools/install-ci-tools
       - jq/install
 
       - unless:

--- a/src/commands/hadolint.yml
+++ b/src/commands/hadolint.yml
@@ -1,0 +1,61 @@
+description: >
+  Lint a given Dockerfile using a hadolint Docker image:
+  https://hub.docker.com/r/hadolint/hadolint
+
+parameters:
+  dockerfiles:
+    type: string
+    default: Dockerfile
+    description: >
+      Relative or absolute path, including name, to Dockerfile(s) to be
+      linted, e.g., `~/project/app/deploy.Dockerfile`, defaults to a
+      Dockerfile named `Dockerfile` in the working directory. To lint
+      multiple Dockerfiles, pass a colon-separated string, e.g.,
+      `~/project/app/deploy.Dockerfile:~/project/app/test.Dockerfile`.
+
+  ignore-rules:
+    type: string
+    default: ""
+    description: >
+      Comma-separated string list of rules to ignore (e.g.,
+      `DL3000,SC1010`): https://github.com/hadolint/hadolint#rules
+
+  trusted-registries:
+    type: string
+    default: ""
+    description: >
+      Comma-separated list of trusted registries (e.g.,
+      `docker.io,my-company.com:5000`); if set, return an error if
+      Dockerfiles use any images from registries not included in this list
+
+steps:
+  - run:
+      name: Lint <<parameters.dockerfiles>> with hadolint
+      command: |
+        <<#parameters.ignore-rules>>
+        IGNORE_STRING=<<parameters.ignore-rules>>
+        IGNORE_RULES=$(echo "--ignore ${IGNORE_STRING//,/ --ignore }")
+        <</parameters.ignore-rules>>
+
+        <<#parameters.trusted-registries>>
+        REGISTRIES_STRING=<<parameters.trusted-registries>>
+        TRUSTED_REGISTRIES=$(echo "--trusted-registry ${REGISTRIES_STRING//,/ --trusted-registry }")
+        <</parameters.trusted-registries>>
+
+        echo "Running hadolint with the following options..."
+        echo "$IGNORE_RULES"
+        echo "$TRUSTED_REGISTRIES"
+
+        DOCKERFILES=<<parameters.dockerfiles>>
+
+        # use colon delimiters to create array
+        arrDOCKERFILES=(${DOCKERFILES//:/ })
+        let END=${#arrDOCKERFILES[@]}
+
+        for ((i=0;i<END;i++)); do
+          DOCKERFILE="${arrDOCKERFILES[i]}"
+
+          hadolint<<#parameters.ignore-rules>> $IGNORE_RULES<</parameters.ignore-rules>> <<#parameters.trusted-registries>>$TRUSTED_REGISTRIES <</parameters.trusted-registries>>$DOCKERFILE
+
+          echo "Success! $DOCKERFILE linted; no issues found"
+        done

--- a/src/jobs/hadolint.yml
+++ b/src/jobs/hadolint.yml
@@ -85,33 +85,7 @@ steps:
         - attach_workspace:
             at: <<parameters.workspace-root>>
 
-  - run:
-      name: Lint <<parameters.dockerfiles>> with hadolint
-      command: |
-        <<#parameters.ignore-rules>>
-        IGNORE_STRING=<<parameters.ignore-rules>>
-        IGNORE_RULES=$(echo "--ignore ${IGNORE_STRING//,/ --ignore }")
-        <</parameters.ignore-rules>>
-
-        <<#parameters.trusted-registries>>
-        REGISTRIES_STRING=<<parameters.trusted-registries>>
-        TRUSTED_REGISTRIES=$(echo "--trusted-registry ${REGISTRIES_STRING//,/ --trusted-registry }")
-        <</parameters.trusted-registries>>
-
-        echo "Running hadolint with the following options..."
-        echo "$IGNORE_RULES"
-        echo "$TRUSTED_REGISTRIES"
-
-        DOCKERFILES=<<parameters.dockerfiles>>
-
-        # use colon delimiters to create array
-        arrDOCKERFILES=(${DOCKERFILES//:/ })
-        let END=${#arrDOCKERFILES[@]}
-
-        for ((i=0;i<END;i++)); do
-          DOCKERFILE="${arrDOCKERFILES[i]}"
-
-          hadolint<<#parameters.ignore-rules>> $IGNORE_RULES<</parameters.ignore-rules>> <<#parameters.trusted-registries>>$TRUSTED_REGISTRIES <</parameters.trusted-registries>>$DOCKERFILE
-
-          echo "Success! $DOCKERFILE linted; no issues found"
-        done
+  - hadolint:
+      dockerfiles: <<parameters.dockerfiles>>
+      ignore-rules: <<parameters.ignore-rules>>
+      trusted-registries: <<parameters.trusted-registries>>


### PR DESCRIPTION
Technically no breaking changes but does include a new command.

closes #42 