### PR TITLE
[semver:major] Updated default image to ubuntu-2004:202107-02

### DIFF
--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   image:
     type: string
-    default: ubuntu-1604:201903-01
+    default: ubuntu-2004:202107-02
 
   dlc:
     type: boolean


### PR DESCRIPTION
- Updated default image to the latest Ubuntu image