### PR TITLE
Amend "[semver:major] Updated default image to ubuntu-2004:202107-02"

### DIFF
--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   image:
     type: string
-    default: ubuntu-2004:202107-02
+    default: ubuntu-1604:201903-01
 
   dlc:
     type: boolean


### PR DESCRIPTION
Reverts CircleCI-Public/docker-orb#86 due to incorrect merge formatting 