### PR TITLE
[semver:patch] Add missing name on pull command

### DIFF
--- a/src/commands/pull.yml
+++ b/src/commands/pull.yml
@@ -14,8 +14,10 @@ steps:
   - when:
       condition: <<parameters.images>>
       steps:
-        - run: |
-            echo "<<parameters.images>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
-              echo "Pulling ${image}";
-              docker pull ${image} <<#parameters.ignore-docker-pull-error>>|| true<</parameters.ignore-docker-pull-error>>
-            done
+        - run:
+            name: Docker pull
+            command: |
+              echo "<<parameters.images>>" | sed -n 1'p' | tr ',' '\n' | while read image; do
+                echo "Pulling ${image}";
+                docker pull ${image} <<#parameters.ignore-docker-pull-error>>|| true<</parameters.ignore-docker-pull-error>>
+              done


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The pull command is missing a name, resulting in a weird display on the CircleCI GUI.

### Description

This adds a name to the pull command