### PR TITLE
fix command get latest docker compose version

### DIFF
--- a/src/commands/install-docker-compose.yml
+++ b/src/commands/install-docker-compose.yml
@@ -26,7 +26,7 @@ steps:
 
         # grab docker-compose version
         if [[ <<parameters.version>> == "latest" ]]; then
-          DOCKER_COMPOSE_VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w %{url_effective} "https://github.com/docker/compose/releases/latest" | sed 's:.*/::')
+          DOCKER_COMPOSE_VERSION=$(curl -s --fail --retry 3 "https://github.com/docker/compose/releases/" | grep -Eoi '<a [^>]+>' | grep -Eo 'href="[^\"]+"'| grep x86_64 | head -1 | awk -F'/' '{print $6}')
           echo "Latest stable version of docker-compose is $DOCKER_COMPOSE_VERSION"
         else
           DOCKER_COMPOSE_VERSION=<<parameters.version>>


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
This PR is meant to fix the [issue 94](https://github.com/CircleCI-Public/docker-orb/issues/94). The latest version of docker-compose at the time of reporting doesn't have versions for `x86_64`. That cause the script to download the docker-compose binary failed. 

### Description
Instead of getting the latest release, I modify the script to get the latest release containing the version for `x86_64`.
