### PR TITLE
Fix typo in the build command description

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -29,8 +29,8 @@ parameters:
     type: boolean
     default: false
     description: >
-      If linting Dockerfile, treat linting warnings as errors (would trigger
-      an exist code and fail the CircleCI job)?
+      If linting Dockerfile, treat linting warnings as errors? (would trigger
+      an exit code and fail the CircleCI job)
 
   registry:
     type: string


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Improve quality.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Fixes a minor typo in the description of the `build` command.