### PR TITLE
Use next-gen Docker convenience image

### DIFF
--- a/src/executors/docker.yml
+++ b/src/executors/docker.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   image:
     type: string
-    default: circleci/python
+    default: cimg/python
     description: Docker image name
 
   tag:


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

When using the docker executor, a warning is displayed on CircleCI:
```
You’re using a deprecated Docker convenience image. Upgrade to a next-gen Docker convenience image.
```
See https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

### Description

Replace deprecated circle/docker image with the next-gen on cimg/docker.