### PR TITLE
Bump "macos-old" version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ parameters:
 executors:
   macos-old:
     macos:
-      xcode: 10.3.0
+      xcode: 11.7.0
   macos-latest:
     macos:
       xcode: 13.1.0


### PR DESCRIPTION
As part of CPE-554 we want to cut down usage of the old Xcode 10.3 image as much as possible
