### PR TITLE
Fix parsing filename out of checksum

### DIFF
--- a/src/commands/install-docker-compose.yml
+++ b/src/commands/install-docker-compose.yml
@@ -71,7 +71,7 @@ steps:
           --silent --show-error --location --fail --retry 3 \
           "$DOCKER_COMPOSE_SHASUM_URL"
 
-        FILENAME=$(cat docker-compose-$PLATFORM-x86_64.sha256 | awk '{ print $NF }') | sed 's/^\*//'
+        FILENAME=$(cat docker-compose-$PLATFORM-x86_64.sha256 | awk '{ print $NF }' | sed 's/^\*//')
 
         curl -O \
           --silent --show-error --location --fail --retry 3 \

--- a/src/commands/install-docker-compose.yml
+++ b/src/commands/install-docker-compose.yml
@@ -71,7 +71,7 @@ steps:
           --silent --show-error --location --fail --retry 3 \
           "$DOCKER_COMPOSE_SHASUM_URL"
 
-        FILENAME=$(cat docker-compose-$PLATFORM-x86_64.sha256 | awk '{ print $NF }')
+        FILENAME=$(cat docker-compose-$PLATFORM-x86_64.sha256 | awk '{ print $NF }') | sed 's/^\*//'
 
         curl -O \
           --silent --show-error --location --fail --retry 3 \


### PR DESCRIPTION
In the [2.5.0 release](https://github.com/docker/compose/releases/tag/v2.5.0), The Docker Compose checksum is [now calculated with the `--binary` flag](https://github.com/docker/compose/pull/9389), causing a leading asterisk to be added to the filename in the output.