### PR TITLE
fix: misleading description for path parameter

### DIFF
--- a/src/commands/update-description.yml
+++ b/src/commands/update-description.yml
@@ -10,7 +10,7 @@ parameters:
     type: string
     default: .
     description: >
-      Path to the directory containing your Dockerfile and build context,
+      Path to the directory containing your Dockerfile,
       defaults to . (working directory)
 
   registry:

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -38,7 +38,7 @@ parameters:
     type: string
     default: .
     description: >
-      Path to the directory containing your Dockerfile and build context,
+      Path to the directory containing your Dockerfile,
       defaults to . (working directory)
 
   lint-dockerfile:


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Closes #78 

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
