### PR TITLE
Update build_args to fix multiple tags

### DIFF
--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -66,7 +66,9 @@ fi
 # The context must be the last argument.
 build_args+=("$PARAM_DOCKER_CONTEXT")
 
+# recreate build_args array so it doesn't group multiple args as a single variable
 build_args=( $(eval echo "${build_args[@]}") )
+
 set -x
 docker build "${build_args[@]}"
 set +x

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -66,6 +66,7 @@ fi
 # The context must be the last argument.
 build_args+=("$PARAM_DOCKER_CONTEXT")
 
+build_args=( $(eval echo "${build_args[@]}") )
 set -x
 docker build "${build_args[@]}"
 set +x


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

This change updates the build_args array so that it breaks each value by a space. 

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Update build_args array so that docker cli handles args properly and doesn't group multiple args as one. 

E.g.
```
docker build --file=./Dockerfile '--tag=docker.io/{org]/{image}:{tag} --tag=docker.io/{org}/{image}:{tag2}'

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
