### PR TITLE
fix: replace `deploy` steps to `run`

### DIFF
--- a/src/commands/push.yml
+++ b/src/commands/push.yml
@@ -27,7 +27,7 @@ parameters:
     default: ""
 
 steps:
-  - deploy:
+  - run:
       name: <<parameters.step-name>>
       environment:
         PARAM_REGISTRY: <<parameters.registry>>

--- a/src/commands/update-description.yml
+++ b/src/commands/update-description.yml
@@ -36,7 +36,7 @@ parameters:
       Name of environment variable storing your Docker password
 
 steps:
-  - deploy:
+  - run:
       name: Update description
       environment:
         PARAM_README: <<parameters.readme>>


### PR DESCRIPTION
### Checklist

Updates `deploy` steps to use `run` instead.

Resolves https://github.com/CircleCI-Public/docker-orb/issues/128

I was able to verify that compiled Orb is valid:

```console
$ circleci orb process src/@orb.yml > orb.yml
$ circleci orb validate orb.yml
Orb at `orb.yml` is valid.
```

I checked that the `update-description` command is also tested under the `publish-docker-update-description` test case.

example: https://app.circleci.com/pipelines/github/CircleCI-Public/docker-orb/796/workflows/92fbd710-d32d-492a-b4e0-79362afef857/jobs/13674


<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
