### PR TITLE
fix: import the `push.sh` script in the push command

### DIFF
--- a/src/commands/push.yml
+++ b/src/commands/push.yml
@@ -34,14 +34,4 @@ steps:
         PARAM_IMAGE: <<parameters.image>>
         PARAM_TAG: <<parameters.tag>>
         PARAM_DIGEST_PATH: <<parameters.digest-path>>
-      command: |
-        IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
-        for tag in "${DOCKER_TAGS[@]}"; do
-          docker push <<parameters.registry>>/<< parameters.image>>:${tag}
-        done
-
-        if [ -n "<<parameters.digest-path>>" ]; then
-          mkdir -p "$(dirname <<parameters.digest-path>>)"
-          IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
-          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry>>/<< parameters.image>>:"${DOCKER_TAGS[0]}" > "<<parameters.digest-path>>"
-        fi
+      command: << include(scripts/push.sh) >>

--- a/src/scripts/push.sh
+++ b/src/scripts/push.sh
@@ -10,5 +10,6 @@ done
 if [ -n "$PARAM_DIGEST_PATH" ]; then
   mkdir -p "$(dirname "$PARAM_DIGEST_PATH")"
   IFS="," read -ra DOCKER_TAGS <<< "$PARAM_TAG"
-  docker image inspect --format="{{index .RepoDigests 0}}" "$PARAM_REGISTRY"/"$PARAM_IMAGE":"${DOCKER_TAGS[0]}" > "$PARAM_DIGEST_PATH"
+  tag=$(eval echo "${DOCKER_TAGS[0]}")
+  docker image inspect --format="{{index .RepoDigests 0}}" "$PARAM_REGISTRY"/"$PARAM_IMAGE":"$tag" > "$PARAM_DIGEST_PATH"
 fi

--- a/src/scripts/push.sh
+++ b/src/scripts/push.sh
@@ -2,8 +2,9 @@
 
 IFS="," read -ra DOCKER_TAGS <<< "$PARAM_TAG"
 
-for tag in "${DOCKER_TAGS[@]}"; do
-  docker push "$PARAM_REGISTRY"/"$PARAM_IMAGE":${tag}
+for docker_tag in "${DOCKER_TAGS[@]}"; do
+  tag=$(eval echo "$docker_tag")
+  docker push "$PARAM_REGISTRY"/"$PARAM_IMAGE":"$tag"
 done
 
 if [ -n "$PARAM_DIGEST_PATH" ]; then


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

New PRs are failing the review step because the push command has bash in it. Even though the script was extracted in #120, the code was never replaced with it.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Replace the bash code with an import containing the script path.
