### PR TITLE
fix: issues related to `push`, `update-description` and `install-docker-compose`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -457,10 +457,10 @@ workflows:
 executors:
   macos-old:
     macos:
-      xcode: 10.3.0
+      xcode: 11.7.0
   macos-latest:
     macos:
-      xcode: 13.1.0
+      xcode: 14.0.0
   docker-old:
     docker:
       - image: cimg/base:2020.08-20.04

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,6 +16,7 @@ promotion_requires: &promotion_requires
     publish-docker-cache-not-found,
     publish-docker-with-buildkit,
     publish-docker-multiple-tags,
+    publish-docker-env-var-image-param,
     test-pull,
     test-install-docker-tools-docker-latest,
     test-install-docker-tools-docker-old,
@@ -384,6 +385,21 @@ workflows:
           use-remote-docker: true
           dockerfile: test.Dockerfile
           image: cpeorbtesting/docker-orb-test
+          tag: $CIRCLE_SHA1,$CIRCLE_BUILD_NUM
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          use-docker-credentials-store: true
+          filters: *filters
+      - docker/publish:
+          pre-steps:
+            - run: echo 'export DOCKER_USERNAME=cpeorbtesting' >> $BASH_ENV
+            - run: echo 'export DOCKER_NAME=docker-orb-test' >> $BASH_ENV
+          name: publish-docker-env-var-image-param
+          executor: docker-latest
+          context: CPE-orb-docker-testing
+          use-remote-docker: true
+          dockerfile: test.Dockerfile
+          image: $DOCKER_USERNAME/$DOCKER_NAME
           tag: $CIRCLE_SHA1,$CIRCLE_BUILD_NUM
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS

--- a/src/commands/update-description.yml
+++ b/src/commands/update-description.yml
@@ -36,6 +36,7 @@ parameters:
       Name of environment variable storing your Docker password
 
 steps:
+  - jq/install
   - run:
       name: Update description
       environment:

--- a/src/scripts/install-docker-compose.sh
+++ b/src/scripts/install-docker-compose.sh
@@ -33,7 +33,7 @@ if command -v docker-compose &> /dev/null; then
   fi
 fi
 
-# get binary/shasum download URL for specified version
+# get binary download URL for specified version
 if uname -a | grep Darwin &> /dev/null; then
   PLATFORM=darwin
   HOMEBREW_NO_AUTO_UPDATE=1 brew install coreutils
@@ -41,29 +41,13 @@ else
   PLATFORM=linux
 fi
 
+FILENAME="docker-compose-$PLATFORM-x86_64"
 DOCKER_COMPOSE_BASE_URL="https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION"
-DOCKER_COMPOSE_SHASUM_URL="$DOCKER_COMPOSE_BASE_URL/docker-compose-$PLATFORM-x86_64.sha256"
 
-# download binary and shasum
-curl -O \
-  --silent --show-error --location --fail --retry 3 \
-  "$DOCKER_COMPOSE_SHASUM_URL"
-
-FILENAME=$(cat docker-compose-$PLATFORM-x86_64.sha256 | awk '{ print $NF }' | sed 's/^\*//')
-
+# download binary
 curl -O \
   --silent --show-error --location --fail --retry 3 \
   "$DOCKER_COMPOSE_BASE_URL/$FILENAME"
-
-set +e
-grep "$FILENAME" docker-compose-$PLATFORM-x86_64.sha256 | sha256sum -c -
-SHASUM_SUCCESS=$?
-set -e
-
-if [[ "$SHASUM_SUCCESS" -ne 0 ]]; then
-  echo "Checksum validation failed for $FILENAME"
-  exit 1
-fi
 
 # install docker-compose
 $SUDO mv "$FILENAME" "$PARAM_INSTALL_DIR"/docker-compose

--- a/src/scripts/push.sh
+++ b/src/scripts/push.sh
@@ -2,14 +2,19 @@
 
 IFS="," read -ra DOCKER_TAGS <<< "$PARAM_TAG"
 
+image="$(eval echo "$PARAM_IMAGE")"
+
 for docker_tag in "${DOCKER_TAGS[@]}"; do
   tag=$(eval echo "$docker_tag")
-  docker push "$PARAM_REGISTRY"/"$PARAM_IMAGE":"$tag"
+
+  set -x
+  docker push "$PARAM_REGISTRY"/"$image":"$tag"
+  set +x
 done
 
 if [ -n "$PARAM_DIGEST_PATH" ]; then
   mkdir -p "$(dirname "$PARAM_DIGEST_PATH")"
   IFS="," read -ra DOCKER_TAGS <<< "$PARAM_TAG"
   tag=$(eval echo "${DOCKER_TAGS[0]}")
-  docker image inspect --format="{{index .RepoDigests 0}}" "$PARAM_REGISTRY"/"$PARAM_IMAGE":"$tag" > "$PARAM_DIGEST_PATH"
+  docker image inspect --format="{{index .RepoDigests 0}}" "$PARAM_REGISTRY"/"$image":"$tag" > "$PARAM_DIGEST_PATH"
 fi

--- a/src/scripts/update-description.sh
+++ b/src/scripts/update-description.sh
@@ -7,12 +7,13 @@ fi
 
 USERNAME=${!PARAM_DOCKER_USERNAME}
 PASSWORD=${!PARAM_DOCKER_PASSWORD}
+IMAGE="$(eval echo "$PARAM_IMAGE")"
 
 DESCRIPTION="$PARAM_PATH/$PARAM_README"
 PAYLOAD="username=$USERNAME&password=$PASSWORD"
 JWT=$(curl -s -d "$PAYLOAD" https://hub.docker.com/v2/users/login/ | jq -r .token)
 HEADER="Authorization: JWT $JWT"
-URL="https://hub.docker.com/v2/repositories/$PARAM_IMAGE/"
+URL="https://hub.docker.com/v2/repositories/$IMAGE/"
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH -H "$HEADER" --data-urlencode full_description@$DESCRIPTION $URL)
 
 if [ $STATUS -ne 200 ]; then

--- a/src/scripts/update-description.sh
+++ b/src/scripts/update-description.sh
@@ -14,7 +14,7 @@ PAYLOAD="username=$USERNAME&password=$PASSWORD"
 JWT=$(curl -s -d "$PAYLOAD" https://hub.docker.com/v2/users/login/ | jq -r .token)
 HEADER="Authorization: JWT $JWT"
 URL="https://hub.docker.com/v2/repositories/$IMAGE/"
-STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH -H "$HEADER" --data-urlencode full_description@$DESCRIPTION $URL)
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH -H "$HEADER" -H 'Content-type: application/json' --data "{\"full_description\": $(jq -Rs '.' $DESCRIPTION)}" $URL)
 
 if [ $STATUS -ne 200 ]; then
   echo "Could not update image description"


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Ever since the shell code in YAML was replaced with its dedicated file in #131, the `publish` job lost support for environment variables in the `image` parameter. This PR will bring back support.

- Closes #136
- Closes #139 

The Docker Hub API only supports `application/json` now. This PR changes the `update-description` command to send JSON in the request body instead of `x-www-form-urlencoded`.

- Closes #138

The latest release (v2.10.0) of Docker Compose does not have `sha` files. This makes the `install-docker-compose` command fail with a 404 error from `curl`. This PR removes the sha verification for the time being.

- Closes #140

### Description

Variable expansion via `eval echo` was included in all pertinent scripts. And a new test was included in the suite to cover this use case (#136, #139).

Changes the Docker Hub API request to send a JSON payload (#138). Thank for the suggestion, @zigarn!

Removes the sha verification as the latest Docker Compose release does not come with the files (#140).