### PR TITLE
fix: support for env vars parameters in `publish`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -457,10 +457,10 @@ workflows:
 executors:
   macos-old:
     macos:
-      xcode: 10.3.0
+      xcode: 11.7.0
   macos-latest:
     macos:
-      xcode: 13.1.0
+      xcode: 14.0.0
   docker-old:
     docker:
       - image: cimg/base:2020.08-20.04

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,6 +16,7 @@ promotion_requires: &promotion_requires
     publish-docker-cache-not-found,
     publish-docker-with-buildkit,
     publish-docker-multiple-tags,
+    publish-docker-env-var-image-param,
     test-pull,
     test-install-docker-tools-docker-latest,
     test-install-docker-tools-docker-old,
@@ -384,6 +385,21 @@ workflows:
           use-remote-docker: true
           dockerfile: test.Dockerfile
           image: cpeorbtesting/docker-orb-test
+          tag: $CIRCLE_SHA1,$CIRCLE_BUILD_NUM
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          use-docker-credentials-store: true
+          filters: *filters
+      - docker/publish:
+          pre-steps:
+            - run: echo 'export DOCKER_USERNAME=cpeorbtesting' >> $BASH_ENV
+            - run: echo 'export DOCKER_NAME=docker-orb-test' >> $BASH_ENV
+          name: publish-docker-env-var-image-param
+          executor: docker-latest
+          context: CPE-orb-docker-testing
+          use-remote-docker: true
+          dockerfile: test.Dockerfile
+          image: $DOCKER_USERNAME/$DOCKER_NAME
           tag: $CIRCLE_SHA1,$CIRCLE_BUILD_NUM
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS

--- a/src/scripts/push.sh
+++ b/src/scripts/push.sh
@@ -2,14 +2,19 @@
 
 IFS="," read -ra DOCKER_TAGS <<< "$PARAM_TAG"
 
+image="$(eval echo "$PARAM_IMAGE")"
+
 for docker_tag in "${DOCKER_TAGS[@]}"; do
   tag=$(eval echo "$docker_tag")
-  docker push "$PARAM_REGISTRY"/"$PARAM_IMAGE":"$tag"
+
+  set -x
+  docker push "$PARAM_REGISTRY"/"$image":"$tag"
+  set +x
 done
 
 if [ -n "$PARAM_DIGEST_PATH" ]; then
   mkdir -p "$(dirname "$PARAM_DIGEST_PATH")"
   IFS="," read -ra DOCKER_TAGS <<< "$PARAM_TAG"
   tag=$(eval echo "${DOCKER_TAGS[0]}")
-  docker image inspect --format="{{index .RepoDigests 0}}" "$PARAM_REGISTRY"/"$PARAM_IMAGE":"$tag" > "$PARAM_DIGEST_PATH"
+  docker image inspect --format="{{index .RepoDigests 0}}" "$PARAM_REGISTRY"/"$image":"$tag" > "$PARAM_DIGEST_PATH"
 fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Ever since the shell code in YAML was replaced with its dedicated file in #131, the `publish` job lost support for environment variables in the `image` parameter. This PR will bring back support.

- Closes #136
- Closes #139 

### Description

Variable expansion via `eval echo` was included in all pertinent scripts. And a new test was included in the suite to cover this use case (#136, #139).
