### PR TITLE
fix: payload used in the update description request

### DIFF
--- a/src/commands/update-description.yml
+++ b/src/commands/update-description.yml
@@ -36,6 +36,7 @@ parameters:
       Name of environment variable storing your Docker password
 
 steps:
+  - jq/install
   - run:
       name: Update description
       environment:

--- a/src/scripts/update-description.sh
+++ b/src/scripts/update-description.sh
@@ -7,13 +7,14 @@ fi
 
 USERNAME=${!PARAM_DOCKER_USERNAME}
 PASSWORD=${!PARAM_DOCKER_PASSWORD}
+IMAGE="$(eval echo "$PARAM_IMAGE")"
 
 DESCRIPTION="$PARAM_PATH/$PARAM_README"
 PAYLOAD="username=$USERNAME&password=$PASSWORD"
 JWT=$(curl -s -d "$PAYLOAD" https://hub.docker.com/v2/users/login/ | jq -r .token)
 HEADER="Authorization: JWT $JWT"
-URL="https://hub.docker.com/v2/repositories/$PARAM_IMAGE/"
-STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH -H "$HEADER" --data-urlencode full_description@$DESCRIPTION $URL)
+URL="https://hub.docker.com/v2/repositories/$IMAGE/"
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH -H "$HEADER" -H 'Content-type: application/json' --data "{\"full_description\": $(jq -Rs '.' $DESCRIPTION)}" $URL)
 
 if [ $STATUS -ne 200 ]; then
   echo "Could not update image description"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The Docker Hub API only supports `application/json` now. This PR changes the `update-description` command to send JSON in the request body instead of `x-www-form-urlencoded`.

- Closes #138

### Description

Changes the Docker Hub API request to send a JSON payload (#138). Thank for the suggestion, @zigarn!