### PR TITLE
chore: bump orb dependencies and remove deprecated commands

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,6 +8,5 @@ display:
   source_url: https://github.com/CircleCI-Public/docker-orb
 
 orbs:
-  bt: circleci/build-tools@2.6.3
-  jq: circleci/jq@2.0
-  orb-tools: circleci/orb-tools@9.1
+  bt: circleci/build-tools@3.0
+  jq: circleci/jq@2.2

--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -29,12 +29,6 @@ parameters:
       This option is only supported on Ubuntu/Debian/macOS platforms.
 
 steps:
-  - orb-tools/check-env-var-param:
-      param: <<parameters.docker-username>>
-
-  - orb-tools/check-env-var-param:
-      param: <<parameters.docker-password>>
-
   - when:
       condition: <<parameters.use-docker-credentials-store>>
       steps:


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The orb's dependencies were outdated.

### Description

Bump `jq` and `build-tools` and remove `orb-tools` and its commands.
