### PR TITLE
Fixes #154 by altering the architecture name when helper > 0.6.0

### DIFF
--- a/src/scripts/install-docker-credential-helper.sh
+++ b/src/scripts/install-docker-credential-helper.sh
@@ -69,8 +69,7 @@ if [ "$(echo ${RELEASE_VERSION} | cut -d. -f2)" -gt 6 ]; then
     TAR_FILE="false"
 fi
 
-DOWNLOAD_URL="https://github.com/docker/docker-credential-helpers/releases/download/${RELEASE_VERSION}/${HE
-LPER_FILENAME}-${RELEASE_VERSION}-${PLATFORM_NAME}"
+DOWNLOAD_URL="https://github.com/docker/docker-credential-helpers/releases/download/${RELEASE_VERSION}/${HELPER_FILENAME}-${RELEASE_VERSION}-${PLATFORM_NAME}"
 
 if [ "${TAR_FILE}" == 'true' ]; then
     DOWNLOAD_URL="${DOWNLOAD_URL}.tar.gz"

--- a/src/scripts/install-docker-credential-helper.sh
+++ b/src/scripts/install-docker-credential-helper.sh
@@ -59,7 +59,12 @@ RELEASE_VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w '%{url_effective}' "
 if [ -n "${RELEASE_TAG}" ]; then
   RELEASE_VERSION="${RELEASE_TAG}"
 fi
-DOWNLOAD_URL="https://github.com/docker/docker-credential-helpers/releases/download/${RELEASE_VERSION}/${HELPER_FILENAME}-${RELEASE_VERSION}-amd64.tar.gz"
+PLATFORM_NAME="amd64"
+if [ "$(echo ${RELEASE_VERSION} | cut -d. -f2)" -gt 6 ]; then
+    # docker-credentials-helper changed platform name from architecture to OS type from 0.7.0 onward
+    PLATFORM_NAME="linux"
+fi
+DOWNLOAD_URL="https://github.com/docker/docker-credential-helpers/releases/download/${RELEASE_VERSION}/${HELPER_FILENAME}-${RELEASE_VERSION}-${PLATFORM_NAME}.tar.gz"
 
 echo "Downloading from url: $DOWNLOAD_URL"
 curl -L -o "${HELPER_FILENAME}_archive" "$DOWNLOAD_URL"

--- a/src/scripts/install-docker-credential-helper.sh
+++ b/src/scripts/install-docker-credential-helper.sh
@@ -59,16 +59,28 @@ RELEASE_VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w '%{url_effective}' "
 if [ -n "${RELEASE_TAG}" ]; then
   RELEASE_VERSION="${RELEASE_TAG}"
 fi
+
 PLATFORM_NAME="amd64"
+TAR_FILE="true"
 if [ "$(echo ${RELEASE_VERSION} | cut -d. -f2)" -gt 6 ]; then
-    # docker-credentials-helper changed platform name from architecture to OS type from 0.7.0 onward
+    # docker-credentials-helper changed platform name from
+    # architecture to OS type from 0.7.0 onward and does not supply a tarfile artefact
     PLATFORM_NAME="linux"
+    TAR_FILE="false"
 fi
-DOWNLOAD_URL="https://github.com/docker/docker-credential-helpers/releases/download/${RELEASE_VERSION}/${HELPER_FILENAME}-${RELEASE_VERSION}-${PLATFORM_NAME}.tar.gz"
+
+DOWNLOAD_URL="https://github.com/docker/docker-credential-helpers/releases/download/${RELEASE_VERSION}/${HE
+LPER_FILENAME}-${RELEASE_VERSION}-${PLATFORM_NAME}"
+
+if [ "${TAR_FILE}" == 'true' ]; then
+    DOWNLOAD_URL="${DOWNLOAD_URL}.tar.gz"
+fi
 
 echo "Downloading from url: $DOWNLOAD_URL"
 curl -L -o "${HELPER_FILENAME}_archive" "$DOWNLOAD_URL"
-tar xvf "./${HELPER_FILENAME}_archive"
+if [ "${TAR_FILE}" == 'true' ]; then
+    tar xvf "./${HELPER_FILENAME}_archive"
+fi
 chmod +x "./$HELPER_FILENAME"
 
 $SUDO mv "./$HELPER_FILENAME" "$BIN_PATH/$HELPER_FILENAME"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

(none of the above apply as this is a hotfix)

### Motivation, issues

This fixes the currently failing "install-docker-credential-helper" command because of an upstream artefact naming change.

### Description

This provides a backward-compatible way to allow the command to continue running.