### PR TITLE
fix: error when downloading the credential helper's latest version

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -11,6 +11,9 @@ promotion_requires: &promotion_requires
     test-credentials-store-docker,
     test-credentials-store-machine,
     test-credentials-store-macos,
+    test-credentials-store-docker-custom-tag,
+    test-credentials-store-machine-custom-tag,
+    test-credentials-store-macos-custom-tag,
     publish-machine,
     publish-docker-cache,
     publish-docker-cache-not-found,
@@ -130,10 +133,14 @@ jobs:
         type: env_var_name
       docker-password:
         type: env_var_name
+      release-tag:
+        type: string
+        default: ""
     executor: <<parameters.executor>>
     steps:
       - docker/install-docker-credential-helper:
           helper-name: <<parameters.helper-name>>
+          release-tag: <<parameters.release-tag>>
       - docker/configure-docker-credentials-store:
           helper-name: <<parameters.helper-name>>
       - run:
@@ -334,6 +341,33 @@ workflows:
           context: CPE-orb-docker-testing
           docker-username: DOCKER_USER
           docker-password: DOCKER_PASS
+          pre-steps:
+            - docker/install-docker
+          filters: *filters
+      - test-credentials-store:
+          name: test-credentials-store-docker-custom-tag
+          executor: docker-latest
+          context: CPE-orb-docker-testing
+          helper-name: pass
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          release-tag: "v0.6.4"
+          filters: *filters
+      - test-credentials-store:
+          name: test-credentials-store-machine-custom-tag
+          executor: machine-latest
+          context: CPE-orb-docker-testing
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          release-tag: "v0.6.4"
+          filters: *filters
+      - test-credentials-store:
+          name: test-credentials-store-macos-custom-tag
+          executor: macos-latest
+          context: CPE-orb-docker-testing
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          release-tag: "v0.6.4"
           pre-steps:
             - docker/install-docker
           filters: *filters

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -71,6 +71,7 @@ old_ifs="$IFS"
 IFS=' '
 
 set -x
+# shellcheck disable=SC2048 # We want word splitting here.
 docker build ${build_args[*]}
 set +x
 

--- a/src/scripts/hadolint.sh
+++ b/src/scripts/hadolint.sh
@@ -1,9 +1,11 @@
 if [ -n "$PARAM_IGNORE_RULES" ]; then
-  readonly ignore_rules=$(printf '%s' "--ignore ${PARAM_IGNORE_RULES//,/ --ignore }")
+  ignore_rules=$(printf '%s' "--ignore ${PARAM_IGNORE_RULES//,/ --ignore }")
+  readonly ignore_rules
 fi
 
 if [ -n "$PARAM_TRUSTED_REGISTRIES" ]; then
-  readonly trusted_registries=$(printf '%s' "--trusted-registry ${PARAM_TRUSTED_REGISTRIES//,/ --trusted-registry }")
+  trusted_registries=$(printf '%s' "--trusted-registry ${PARAM_TRUSTED_REGISTRIES//,/ --trusted-registry }")
+  readonly trusted_registries
 fi
 
 printf '%s\n' "Running hadolint with the following options..."

--- a/src/scripts/install-docker-credential-helper.sh
+++ b/src/scripts/install-docker-credential-helper.sh
@@ -2,11 +2,14 @@
 
 HELPER_NAME="$PARAM_HELPER_NAME"
 
+if uname | grep -q "Darwin"; then platform="darwin"
+else platform="linux"
+fi
+
+# Infer helper name from the platform
 if [ -z "${HELPER_NAME}" ]; then
-  if uname | grep -q "Darwin"; then
-    HELPER_NAME="osxkeychain"
-  else
-    HELPER_NAME="pass"
+  if [ "$platform" = "darwin" ]; then HELPER_NAME="osxkeychain"
+  else HELPER_NAME="pass"
   fi
 fi
 
@@ -55,17 +58,28 @@ echo "Downloading credential helper $HELPER_FILENAME"
 BIN_PATH="/usr/local/bin"
 mkdir -p "$BIN_PATH"
 RELEASE_TAG="$PARAM_RELEASE_TAG"
-RELEASE_VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w '%{url_effective}' "https://github.com/docker/docker-credential-helpers/releases/latest" | sed 's:.*/::')
+base_url="https://github.com/docker/docker-credential-helpers/releases"
+RELEASE_VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w '%{url_effective}' "$base_url/latest" | sed 's:.*/::')
 if [ -n "${RELEASE_TAG}" ]; then
   RELEASE_VERSION="${RELEASE_TAG}"
 fi
-DOWNLOAD_URL="https://github.com/docker/docker-credential-helpers/releases/download/${RELEASE_VERSION}/${HELPER_FILENAME}-${RELEASE_VERSION}-amd64.tar.gz"
 
-echo "Downloading from url: $DOWNLOAD_URL"
-curl -L -o "${HELPER_FILENAME}_archive" "$DOWNLOAD_URL"
-tar xvf "./${HELPER_FILENAME}_archive"
+# Starting from v0.7.0, the release file name is changed to docker-credential-<helper-name>-<os>-<arch>
+minor_version="$(echo "$RELEASE_VERSION" | cut -d. -f2)"
+download_base_url="$base_url/download/${RELEASE_VERSION}/${HELPER_FILENAME}-${RELEASE_VERSION}"
+
+if [ "$minor_version" -gt 6 ]; then
+  DOWNLOAD_URL="$download_base_url.$platform-amd64"
+  echo "Downloading from url: $DOWNLOAD_URL"
+  curl -L -o "${HELPER_FILENAME}" "$DOWNLOAD_URL"
+else
+  DOWNLOAD_URL="$download_base_url-amd64.tar.gz"
+  echo "Downloading from url: $DOWNLOAD_URL"
+  curl -L -o "${HELPER_FILENAME}_archive" "$DOWNLOAD_URL"
+  tar xvf "./${HELPER_FILENAME}_archive"
+  rm "./${HELPER_FILENAME}_archive"
+fi
+
 chmod +x "./$HELPER_FILENAME"
-
 $SUDO mv "./$HELPER_FILENAME" "$BIN_PATH/$HELPER_FILENAME"
 "$BIN_PATH/$HELPER_FILENAME" version
-rm "./${HELPER_FILENAME}_archive"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Closes #154 

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

- Change the download URL based on the release's minor version.
- Add tests for release tags other than the latest
