### PR TITLE
Add failure-threshold param

### DIFF
--- a/src/commands/hadolint.yml
+++ b/src/commands/hadolint.yml
@@ -28,6 +28,18 @@ parameters:
       `docker.io,my-company.com:5000`); if set, return an error if
       Dockerfiles use any images from registries not included in this list
 
+  failure-threshold:
+    type: enum
+    default: info
+    description: threshold level to fail on
+    enum:
+      - error
+      - warning
+      - info
+      - style
+      - ignore
+      - none
+
 steps:
   - run:
       name: Lint <<parameters.dockerfiles>> with hadolint
@@ -35,4 +47,5 @@ steps:
         PARAM_DOCKERFILES: <<parameters.dockerfiles>>
         PARAM_IGNORE_RULES: <<parameters.ignore-rules>>
         PARAM_TRUSTED_REGISTRIES: <<parameters.trusted-registries>>
+        HADOLINT_FAILURE_THRESHOLD: <<parameters.failure-threshold>>
       command: <<include(scripts/hadolint.sh)>>

--- a/src/jobs/hadolint.yml
+++ b/src/jobs/hadolint.yml
@@ -55,6 +55,18 @@ parameters:
       will not be usable on CircleCI):
       https://hub.docker.com/r/hadolint/hadolint/tags
 
+  failure-threshold:
+    type: enum
+    default: info
+    description: threshold level to fail on
+    enum:
+      - error
+      - warning
+      - info
+      - style
+      - ignore
+      - none
+
   executor-class:
     type: enum
     default: small
@@ -89,3 +101,4 @@ steps:
       dockerfiles: <<parameters.dockerfiles>>
       ignore-rules: <<parameters.ignore-rules>>
       trusted-registries: <<parameters.trusted-registries>>
+      failure-threshold: <<parameters.failure-threshold>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

It would be great to be able to configure the failure threshold for hadolint

Closes #161 

### Description
- add `failure-threshold` enum param to `hadolint` command
- add `failure-threshold` enum param to `hadolint` job
- add `HADOLINT_FAILURE_THRESHOLD` environment variable to hadolint script step