### PR TITLE
use eval echo for registry

### DIFF
--- a/src/scripts/push.sh
+++ b/src/scripts/push.sh
@@ -3,12 +3,13 @@
 IFS="," read -ra DOCKER_TAGS <<< "$PARAM_TAG"
 
 image="$(eval echo "$PARAM_IMAGE")"
+registry="$(eval echo "$PARAM_REGISTRY")"
 
 for docker_tag in "${DOCKER_TAGS[@]}"; do
   tag=$(eval echo "$docker_tag")
 
   set -x
-  docker push "$PARAM_REGISTRY"/"$image":"$tag"
+  docker push "$registry"/"$image":"$tag"
   set +x
 done
 
@@ -16,5 +17,5 @@ if [ -n "$PARAM_DIGEST_PATH" ]; then
   mkdir -p "$(dirname "$PARAM_DIGEST_PATH")"
   IFS="," read -ra DOCKER_TAGS <<< "$PARAM_TAG"
   tag=$(eval echo "${DOCKER_TAGS[0]}")
-  docker image inspect --format="{{index .RepoDigests 0}}" "$PARAM_REGISTRY"/"$image":"$tag" > "$PARAM_DIGEST_PATH"
+  docker image inspect --format="{{index .RepoDigests 0}}" "$registry"/"$image":"$tag" > "$PARAM_DIGEST_PATH"
 fi


### PR DESCRIPTION
### Checklist
- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

When using an environment variable in the `registry` argument in `docker/push`, it seems like the string is not properly expanded

Should close #151 

### Description

Similar to how tags are interpolated, use `eval echo` to interpolate the value of `registry` in the `docker/push` command