### PR TITLE
Update default machine image to ubuntu-2004:2022.04.1

### DIFF
--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   image:
     type: string
-    default: ubuntu-2004:202107-02
+    default: ubuntu-2004:2022.04.1
 
   dlc:
     type: boolean


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

To be able to use arm resource classes, we need to use a compatible machine image (see https://circleci.com/docs/using-arm/#images-with-arm-support).

### Description

Update default machine image to ubuntu-2004:2022.04.1