### PR TITLE
Expand ENV vars in `cache_from` parameter

### DIFF
--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -57,7 +57,8 @@ if [ -n "$PARAM_EXTRA_BUILD_ARGS" ]; then
 fi
 
 if [ -n "$PARAM_CACHE_FROM" ]; then
-  build_args+=("--cache-from=$PARAM_CACHE_FROM")
+  cache_from="$(eval echo "$PARAM_CACHE_FROM")"
+  build_args+=("--cache-from=$cache_from")
 fi
 
 if [ "$PARAM_USE_BUILDKIT" -eq 1 ]; then


### PR DESCRIPTION
Resolves CircleCI-Public/docker-orb#166.

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

As noted above, this PR resolves CircleCI-Public/docker-orb#166.

### Description

This change _should_ correctly expand ENV variables set in the `cache_from` build parameter. I used a similar approach to the one used in CircleCI-Public/docker-orb#149.