### PR TITLE
Adds support for arm64 architecture while installing goss

### DIFF
--- a/src/commands/install-goss.yml
+++ b/src/commands/install-goss.yml
@@ -27,6 +27,13 @@ parameters:
     description: >
       Extra output for orb developers
 
+  architecture:
+    type: enum
+    default: amd64
+    enum: [ amd64, arm64 ]
+    description: >
+      Which Goss architecture to use. Supports `arm64` architecture from `v0.3.18` and newer.
+
 steps:
   - run:
       name: Install Goss and dgoss
@@ -34,4 +41,5 @@ steps:
         PARAM_VERSION: <<parameters.version>>
         PARAM_INSTALL_DIR: <<parameters.install-dir>>
         PARAM_DEBUG: <<parameters.debug>>
+        PARAM_ARCHITECTURE: <<parameters.architecture>>
       command: << include(scripts/install-goss.sh) >>

--- a/src/scripts/install-goss.sh
+++ b/src/scripts/install-goss.sh
@@ -38,9 +38,9 @@ fi
 # download/install
 # goss
 curl -O --silent --show-error --location --fail --retry 3 \
-  "https://github.com/aelsabbahy/goss/releases/download/$VERSION/goss-linux-amd64"
+  "https://github.com/aelsabbahy/goss/releases/download/$VERSION/goss-linux-$PARAM_ARCHITECTURE"
 
-$SUDO mv goss-linux-amd64 "$PARAM_INSTALL_DIR"/goss
+$SUDO mv goss-linux-$PARAM_ARCHITECTURE "$PARAM_INSTALL_DIR"/goss
 $SUDO chmod +rx /usr/local/bin/goss
 
 # test/verify goss


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

I would like to run goss on ARM architecture which CircleCI added support. To do it ORB should provide option to switch on right architecture.
Tested on private repositories. Solution works as expected.

### Description

Add option `architecture` to command `install-goss` with default value `amd64` to keep backward compatibility.
