### PR TITLE
fix: evaluate and expand all orb parameters

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -43,7 +43,7 @@ promotion_requires: &promotion_requires
 filters: &filters
   tags:
     only: /.*/
-  
+
 orbs:
   build-tools: circleci/build-tools@3.0.0
   docker: circleci/docker@dev:<<pipeline.git.revision>>
@@ -246,7 +246,7 @@ jobs:
       - docker/install-docker
       - docker/install-docker-compose:
           version: << parameters.docker-compose-version>>
-          install-dir: << parameters.install-dir>>  
+          install-dir: << parameters.install-dir>>
 
 workflows:
   test-deploy:
@@ -485,6 +485,27 @@ workflows:
           docker-password: DOCKER_PASS
           use-docker-credentials-store: true
           filters: *filters
+      - docker/publish:
+          pre-steps:
+            - run:
+                name: Export env vars
+                command: |
+                  echo 'export DOCKER_USERNAME=cpeorbtesting' >> $BASH_ENV
+                  echo 'export DOCKER_NAME=docker-orb-test' >> $BASH_ENV
+                  echo 'export DOCKERFILE=test.Dockerfile' >> $BASH_ENV
+                  echo 'export REGISTRY=docker.io' >> $BASH_ENV
+          name: publish-docker-env-var-all-params
+          executor: docker-latest
+          context: CPE-orb-docker-testing
+          use-remote-docker: true
+          dockerfile: $DOCKERFILE
+          image: $DOCKER_USERNAME/$DOCKER_NAME
+          tag: $CIRCLE_SHA1,$CIRCLE_BUILD_NUM
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_PASS
+          use-docker-credentials-store: true
+          registry: $REGISTRY
+          filters: *filters
       # end docker/publish
 
       # begin test-install-docker-tools
@@ -502,7 +523,7 @@ workflows:
           install-goss: false
           filters: *filters
       # end test-install-docker-tools
-      
+
       # begin test
       - test:
           name: test-<< matrix.executor >>
@@ -553,3 +574,5 @@ executors:
   machine-latest:
     machine:
       image: ubuntu-2004:current
+
+# VS Code Extension Version: 1.3.0

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -135,4 +135,5 @@ steps:
         PARAM_REGISTRY: <<parameters.registry>>
         PARAM_TAG: <<parameters.tag>>
         PARAM_USE_BUILDKIT: <<parameters.use-buildkit>>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: <<include(scripts/build.sh)>>

--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -41,4 +41,5 @@ steps:
         PARAM_REGISTRY: <<parameters.registry>>
         PARAM_DOCKER_USERNAME: <<parameters.docker-username>>
         PARAM_DOCKER_PASSWORD: <<parameters.docker-password>>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: <<include(scripts/check.sh)>>

--- a/src/commands/configure-docker-credentials-store.yml
+++ b/src/commands/configure-docker-credentials-store.yml
@@ -24,4 +24,5 @@ steps:
       environment:
         PARAM_HELPER_NAME: "<<parameters.helper-name>>"
         PARAM_DOCKER_CONFIG_PATH: "<<parameters.docker-config-path>>"
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: <<include(scripts/configure-docker-credentials-store.sh)>>

--- a/src/commands/dockerlint.yml
+++ b/src/commands/dockerlint.yml
@@ -30,4 +30,5 @@ steps:
         PARAM_DEBUG: <<parameters.debug>>
         PARAM_TREAT_WARNING_AS_ERRORS: <<parameters.treat-warnings-as-errors>>
         PARAM_DOCKERFILE: <<parameters.dockerfile>>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: <<include(scripts/dockerlint.sh)>>

--- a/src/commands/hadolint.yml
+++ b/src/commands/hadolint.yml
@@ -35,4 +35,5 @@ steps:
         PARAM_DOCKERFILES: <<parameters.dockerfiles>>
         PARAM_IGNORE_RULES: <<parameters.ignore-rules>>
         PARAM_TRUSTED_REGISTRIES: <<parameters.trusted-registries>>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: <<include(scripts/hadolint.sh)>>

--- a/src/commands/install-docker-compose.yml
+++ b/src/commands/install-docker-compose.yml
@@ -25,4 +25,5 @@ steps:
       environment:
         PARAM_DOCKER_COMPOSER_VERSION: << parameters.version >>
         PARAM_INSTALL_DIR: <<parameters.install-dir>>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: <<include(scripts/install-docker-compose.sh)>>

--- a/src/commands/install-docker-credential-helper.yml
+++ b/src/commands/install-docker-credential-helper.yml
@@ -26,4 +26,5 @@ steps:
       environment:
         PARAM_HELPER_NAME: << parameters.helper-name >>
         PARAM_RELEASE_TAG: << parameters.release-tag >>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: << include(scripts/install-docker-credential-helper.sh) >>

--- a/src/commands/install-docker.yml
+++ b/src/commands/install-docker.yml
@@ -25,4 +25,5 @@ steps:
       environment:
         PARAM_VERSION: << parameters.version >>
         PARAM_INSTALL_DIR: << parameters.install-dir >>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: << include(scripts/install-docker.sh) >>

--- a/src/commands/install-dockerize.yml
+++ b/src/commands/install-dockerize.yml
@@ -23,4 +23,5 @@ steps:
       environment:
         PARAM_VERSION: << parameters.version >>
         PARAM_INSTALL_DIR: << parameters.install-dir >>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: << include(scripts/install-dockerize.sh) >>

--- a/src/commands/install-goss.yml
+++ b/src/commands/install-goss.yml
@@ -34,4 +34,5 @@ steps:
         PARAM_VERSION: <<parameters.version>>
         PARAM_INSTALL_DIR: <<parameters.install-dir>>
         PARAM_DEBUG: <<parameters.debug>>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: << include(scripts/install-goss.sh) >>

--- a/src/commands/pull.yml
+++ b/src/commands/pull.yml
@@ -19,4 +19,5 @@ steps:
             environment:
               PARAM_IMAGES: <<parameters.images>>
               PARAM_IGNORE_DOCKER_PULL_ERROR: <<parameters.ignore-docker-pull-error>>
+              SCRIPT_UTILS: <<include(scripts/utils.sh)>>
             command: << include(scripts/pull.sh) >>

--- a/src/commands/push.yml
+++ b/src/commands/push.yml
@@ -34,4 +34,5 @@ steps:
         PARAM_IMAGE: <<parameters.image>>
         PARAM_TAG: <<parameters.tag>>
         PARAM_DIGEST_PATH: <<parameters.digest-path>>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: << include(scripts/push.sh) >>

--- a/src/commands/update-description.yml
+++ b/src/commands/update-description.yml
@@ -46,4 +46,5 @@ steps:
         PARAM_IMAGE: <<parameters.image>>
         PARAM_DOCKER_USERNAME: <<parameters.docker-username>>
         PARAM_DOCKER_PASSWORD: <<parameters.docker-password>>
+        SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: << include(scripts/update-description.sh) >>

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 DOCKER_TAGS_ARG=""
 
 parse_tags_to_docker_arg() {

--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 echo "${!PARAM_DOCKER_PASSWORD}" | docker login -u "${!PARAM_DOCKER_USERNAME}" --password-stdin "$PARAM_REGISTRY"

--- a/src/scripts/configure-docker-credentials-store.sh
+++ b/src/scripts/configure-docker-credentials-store.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 HELPER_NAME="$PARAM_HELPER_NAME"
 DOCKER_CONFIG_PATH="$(eval echo ${PARAM_DOCKER_CONFIG_PATH})"
 

--- a/src/scripts/dockerlint.sh
+++ b/src/scripts/dockerlint.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 if [[ $EUID == 0 ]]; then SUDO=""; else SUDO="sudo"; fi
 
 if ! command -v dockerlint &> /dev/null; then
-  if ! command -v npm &> /dev/null; then 
+  if ! command -v npm &> /dev/null; then
     echo "npm is required to install dockerlint.";
-    echo "Consider running this command with an image that has node available: https://circleci.com/developer/images/image/cimg/node"; 
+    echo "Consider running this command with an image that has node available: https://circleci.com/developer/images/image/cimg/node";
     echo "Alternatively, use dockerlint's docker image: https://github.com/RedCoolBeans/dockerlint#docker-image."
     exit 1
   fi

--- a/src/scripts/hadolint.sh
+++ b/src/scripts/hadolint.sh
@@ -1,3 +1,7 @@
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 if [ -n "$PARAM_IGNORE_RULES" ]; then
   ignore_rules=$(printf '%s' "--ignore ${PARAM_IGNORE_RULES//,/ --ignore }")
   readonly ignore_rules
@@ -16,7 +20,7 @@ printf '%s\n' "$trusted_registries"
 readonly old_ifs="$IFS"
 IFS=":"
 
-read -ra dockerfiles <<< "$PARAM_DOCKERFILES" 
+read -ra dockerfiles <<< "$PARAM_DOCKERFILES"
 IFS="$old_ifs"
 
 for dockerfile in "${dockerfiles[@]}"; do

--- a/src/scripts/install-docker-compose.sh
+++ b/src/scripts/install-docker-compose.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 trap_exit() {
   # clean-up
   printf '%s\n' "Cleaning up..."

--- a/src/scripts/install-docker-credential-helper.sh
+++ b/src/scripts/install-docker-credential-helper.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 HELPER_NAME="$PARAM_HELPER_NAME"
 
 if uname | grep -q "Darwin"; then platform="darwin"

--- a/src/scripts/install-docker.sh
+++ b/src/scripts/install-docker.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 # grab Docker version

--- a/src/scripts/install-dockerize.sh
+++ b/src/scripts/install-dockerize.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 # grab dockerize version

--- a/src/scripts/install-goss.sh
+++ b/src/scripts/install-goss.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 # determine specified version

--- a/src/scripts/pull.sh
+++ b/src/scripts/pull.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 echo "$PARAM_IMAGES" | sed -n 1'p' | tr ',' '\n' | while read -r image; do
   echo "Pulling ${image}";
 

--- a/src/scripts/push.sh
+++ b/src/scripts/push.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 IFS="," read -ra DOCKER_TAGS <<< "$PARAM_TAG"
 
 image="$(eval echo "$PARAM_IMAGE")"

--- a/src/scripts/update-description.sh
+++ b/src/scripts/update-description.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Import "utils.sh".
+eval "$SCRIPT_UTILS"
+expand_env_vars_with_prefix "PARAM_"
+
 if [ "$PARAM_REGISTRY" != "docker.io" ]; then
   echo "Registry is not set to Docker Hub. Exiting"
   exit 1

--- a/src/scripts/utils.sh
+++ b/src/scripts/utils.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Public: Expand the value from environment variables with given prefix.
+#
+# Takes a prefix as an argument and expands the value of the environment variables
+# starting with the prefix. The expansion is done by using the eval command.
+#
+# $1 - Prefix used to filter the envinronment variables.
+#
+# Examples
+#
+#   expand_env_vars_with_prefix "ORB_PARAM_"
+#   expand_env_vars_with_prefix "PARAM_"
+#
+# Returns 1 if no argument is provided or no environment variables were found with prefix.
+# Returns 0 if the expansion was successful.
+expand_env_vars_with_prefix() {
+  if [ "$#" -eq 0 ]; then
+    printf '%s\n' "Please provide a prefix to filter the envinronment variables."
+    return 1
+  fi
+
+  # Fetch parameters from the environment variables.
+  local prefix="$1"
+  local env_vars="$(printenv | grep "^$prefix")"
+
+  if [ -z "$env_vars" ]; then
+    >&2 printf '%s\n' "No environment variables found with the prefix: \"$prefix\"."
+    return 1
+  fi
+
+  while IFS= read -ra line; do
+    # Split the line into key and value.
+    local var_value="${line#*=}"
+    local var_name="${line%="$var_value"}"
+
+    # Expand the value.
+    local expanded_value
+    expanded_value="$(eval echo "$var_value")"
+
+    # The -v option assignes the output to a variable rather than printing it.
+    printf -v "$var_name" "%s" "$expanded_value"
+  done <<< "$env_vars"
+  return 0
+}

--- a/src/scripts/utils.sh
+++ b/src/scripts/utils.sh
@@ -16,13 +16,14 @@
 # Returns 0 if the expansion was successful.
 expand_env_vars_with_prefix() {
   if [ "$#" -eq 0 ]; then
-    printf '%s\n' "Please provide a prefix to filter the envinronment variables."
+    >&2 printf '%s\n' "Please provide a prefix to filter the envinronment variables."
     return 1
   fi
 
   # Fetch parameters from the environment variables.
   local prefix="$1"
-  local env_vars="$(printenv | grep "^$prefix")"
+  local env_vars
+  env_vars="$(printenv | grep "^$prefix")"
 
   if [ -z "$env_vars" ]; then
     >&2 printf '%s\n' "No environment variables found with the prefix: \"$prefix\"."


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Due to the Orb Tools 11 migration, the orb no longer supports environment variables as parameters. The reason behind it is explained in detail [here](https://github.com/CircleCI-Public/docker-orb/issues/135#issuecomment-1159137531). 

While the parameters were not meant to support environment variables unless their type is `env_var_name`, we see an increasing number of issues, such as #151, requesting the functionality back.

This PR leverages the utility function introduced in the [gcp-gke-orb](https://github.com/CircleCI-Public/gcp-gke-orb/pull/57) to expand all variables coming from parameters. Soon, we will introduce a better way of importing and running such functions. When it happens, I'll refactor the changes introduced here.
