### PR TITLE
fix: install hadolint for hadolint command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -14,6 +14,7 @@ promotion_requires: &promotion_requires
     test-credentials-store-docker-custom-tag,
     test-credentials-store-machine-custom-tag,
     test-credentials-store-macos-custom-tag,
+    test-hadolint-install,
     publish-machine,
     publish-docker-cache,
     publish-docker-cache-not-found,
@@ -253,7 +254,25 @@ jobs:
       - docker/install-docker-compose:
           version: << parameters.docker-compose-version>>
           install-dir: << parameters.install-dir>>
-
+  
+  test-hadolint-install:
+    parameters:
+      executor:
+        type: executor
+    executor: << parameters.executor >>
+    steps:
+      - docker/hadolint:
+          dockerfiles: test.Dockerfile
+      - run:
+          name: Verifying hadolint install
+          command: |
+            if [ ! "$(command -v hadolint)"]; then
+              echo "hadolint not installed"
+              exit 1
+            else
+              echo "hadolint installed successfully"
+              exit 0
+            fi
 workflows:
   test-deploy:
     jobs:
@@ -262,6 +281,12 @@ workflows:
           ignore-rules: DL4005,DL3008,DL3009,DL3015,DL3059
           trusted-registries: docker.io,my-company.com:5000
           dockerfiles: test.Dockerfile:test2.Dockerfile
+          filters: *filters
+      - test-hadolint-install:
+          name: test-install-hadolint-<< matrix.executor >>
+          matrix:
+            parameters:
+              executor: [docker-latest, machine-arm, macos-latest]      
           filters: *filters
       - test-dockerlint:
           name: dockerlint

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -261,8 +261,11 @@ jobs:
         type: executor
     executor: << parameters.executor >>
     steps:
+      - checkout
       - docker/hadolint:
           dockerfiles: test.Dockerfile
+          ignore-rules: DL4005,DL3008,DL3009,DL3015
+          trusted-registries: docker.io,my-company.com:5000          
       - run:
           name: Verifying hadolint install
           command: |

--- a/src/commands/hadolint.yml
+++ b/src/commands/hadolint.yml
@@ -1,6 +1,6 @@
 description: >
-  Lint a given Dockerfile using a hadolint Docker image:
-  https://hub.docker.com/r/hadolint/hadolint
+  Lint a given Dockerfile using hadolint. If the hadolint docker image
+  is not used, hadolint will be installed.
 
 parameters:
   dockerfiles:

--- a/src/scripts/hadolint.sh
+++ b/src/scripts/hadolint.sh
@@ -6,7 +6,7 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 Install_Hadolint() {
   if uname -a | grep "Darwin"; then
-    export SYS_ENV_PLATFORM="Darwin"
+    SYS_ENV_PLATFORM="Darwin"
     brew install hadolint
   elif uname -a | grep "x86_64 GNU/Linux"; then
     export SYS_ENV_PLATFORM=Linux-x86_64

--- a/src/scripts/hadolint.sh
+++ b/src/scripts/hadolint.sh
@@ -5,28 +5,29 @@ expand_env_vars_with_prefix "PARAM_"
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 Install_Hadolint() {
-	if uname -a | grep "Darwin"; then
-        	export SYS_ENV_PLATFORM=Darwin-x86_64
-    	elif uname -a | grep "x86_64 GNU/Linux"; then
-        	export SYS_ENV_PLATFORM=Linux-x86_64
-    	elif uname -a | grep  "aarch64 GNU/Linux"; then
-        	export SYS_ENV_PLATFORM=Linux-arm64
+  if uname -a | grep "Darwin"; then
+    brew install hadolint
+  elif uname -a | grep "x86_64 GNU/Linux"; then
+    export SYS_ENV_PLATFORM=Linux-x86_64
+  elif uname -a | grep  "aarch64 GNU/Linux"; then
+    export SYS_ENV_PLATFORM=Linux-arm64
 	else 
 		echo "This platform appears to be unsupported."
-        	uname -a
-        	exit 1
+    uname -a
+    exit 1
 	fi
-
-	set -x
-	$SUDO wget -O /bin/hadolint "https://github.com/hadolint/hadolint/releases/latest/download/hadolint-${SYS_ENV_PLATFORM}"
-	$SUDO chmod +x /bin/hadolint
-	set +x
+	
+  if [ "${SYS_ENV_PLATFORM}" == "x86_64 GNU/Linux" ] || [ "${SYS_ENV_PLATFORM}" == "aarch64 GNU/Linux" ]; then
+    set -x
+    $SUDO wget -O /bin/hadolint "https://github.com/hadolint/hadolint/releases/latest/download/hadolint-${SYS_ENV_PLATFORM}"
+    $SUDO chmod +x /bin/hadolint
+    set +x
+  fi
 }
 
 if [ ! "$(command -v hadolint)" ]; then
 	Install_Hadolint
 fi 
-
 
 if [ -n "$PARAM_IGNORE_RULES" ]; then
   ignore_rules=$(printf '%s' "--ignore ${PARAM_IGNORE_RULES//,/ --ignore }")

--- a/src/scripts/hadolint.sh
+++ b/src/scripts/hadolint.sh
@@ -26,7 +26,7 @@ Install_Hadolint() {
   fi
 }
 
-if [ ! "$(command -v hadolint)" ]; then
+if ! command -v hadolint &> /dev/null; then
 	Install_Hadolint
 fi 
 

--- a/src/scripts/hadolint.sh
+++ b/src/scripts/hadolint.sh
@@ -6,6 +6,7 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 Install_Hadolint() {
   if uname -a | grep "Darwin"; then
+    export SYS_ENV_PLATFORM="Darwin"
     brew install hadolint
   elif uname -a | grep "x86_64 GNU/Linux"; then
     export SYS_ENV_PLATFORM=Linux-x86_64
@@ -17,7 +18,7 @@ Install_Hadolint() {
     exit 1
 	fi
 	
-  if [ "${SYS_ENV_PLATFORM}" == "x86_64 GNU/Linux" ] || [ "${SYS_ENV_PLATFORM}" == "aarch64 GNU/Linux" ]; then
+  if [ "${SYS_ENV_PLATFORM}" != "Darwin" ]; then
     set -x
     $SUDO wget -O /bin/hadolint "https://github.com/hadolint/hadolint/releases/latest/download/hadolint-${SYS_ENV_PLATFORM}"
     $SUDO chmod +x /bin/hadolint

--- a/src/scripts/hadolint.sh
+++ b/src/scripts/hadolint.sh
@@ -2,6 +2,32 @@
 eval "$SCRIPT_UTILS"
 expand_env_vars_with_prefix "PARAM_"
 
+if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+
+Install_Hadolint() {
+	if uname -a | grep "Darwin"; then
+        	export SYS_ENV_PLATFORM=Darwin-x86_64
+    	elif uname -a | grep "x86_64 GNU/Linux"; then
+        	export SYS_ENV_PLATFORM=Linux-x86_64
+    	elif uname -a | grep  "aarch64 GNU/Linux"; then
+        	export SYS_ENV_PLATFORM=Linux-arm64
+	else 
+		echo "This platform appears to be unsupported."
+        	uname -a
+        	exit 1
+	fi
+
+	set -x
+	$SUDO wget -O /bin/hadolint "https://github.com/hadolint/hadolint/releases/latest/download/hadolint-${SYS_ENV_PLATFORM}"
+	$SUDO chmod +x /bin/hadolint
+	set +x
+}
+
+if [ ! "$(command -v hadolint)" ]; then
+	Install_Hadolint
+fi 
+
+
 if [ -n "$PARAM_IGNORE_RULES" ]; then
   ignore_rules=$(printf '%s' "--ignore ${PARAM_IGNORE_RULES//,/ --ignore }")
   readonly ignore_rules


### PR DESCRIPTION
Currently if the `docker/hadolint` command is used with an `executor` other than the `hadolint` docker image, the  command fails. This `PR` installs hadolint if it isn't already. 