### PR TITLE
fix: update dockerfile

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -107,9 +107,9 @@ jobs:
     steps:
       - setup_remote_docker
       - docker/pull:
-          images: cimg/base:stable,ubuntu:18.04
+          images: cimg/base:current,ubuntu:18.04
       - docker/pull:
-          images: cimg/base:stable,cimg/base:not_exists,cimg/go:stable
+          images: cimg/base:current,cimg/base:not_exists,cimg/go:stable
           ignore-docker-pull-error: true
   test-check-command:
     parameters:
@@ -163,7 +163,7 @@ jobs:
             fi
   test-create-workspace:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
     steps:
       - run:
           name: Description
@@ -176,7 +176,7 @@ jobs:
             - verify.txt
   test-build-command-workspace:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
     steps:
       - checkout
       - setup_remote_docker
@@ -199,7 +199,7 @@ jobs:
             fi
   test-build-with-args:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
     steps:
       - checkout
       - setup_remote_docker
@@ -259,7 +259,7 @@ workflows:
     jobs:
       - docker/hadolint:
           name: hadolint
-          ignore-rules: DL4005,DL3008,DL3009,DL3015,DL3059
+          ignore-rules: DL4005,DL3006,DL3008,DL3009,DL3015,DL3059
           trusted-registries: docker.io,my-company.com:5000
           dockerfiles: test.Dockerfile:test2.Dockerfile
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -581,7 +581,7 @@ executors:
       - image: cimg/base:2020.08-20.04
   docker-latest:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
   machine-old:
     machine:
       image: ubuntu-2004:202010-01

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 #
-# The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
+# The Debian-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM debian
+FROM ubuntu:18.04
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 #
-# The Debian-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
+# The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM ubuntu:18.04
+FROM debian
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 
@@ -20,11 +20,9 @@ RUN apt-get update && apt-get install -y \
 	gzip \
 	jq \
 	locales \
-	mercurial \
 	net-tools \
-	netcat \
+	netcat-traditional \
 	openssh-client \
-	parallel \
 	sudo \
 	tar \
 	unzip \

--- a/test2.Dockerfile
+++ b/test2.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM ubuntu:18.04
+FROM debian
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 	locales \
 	mercurial \
 	net-tools \
-	netcat \
+	netcat-traditional \
 	openssh-client \
 	parallel \
 	sudo \

--- a/test2.Dockerfile
+++ b/test2.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM debian
+FROM ubuntu:18.04
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 

--- a/test2.Dockerfile
+++ b/test2.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 

--- a/test3.Dockerfile
+++ b/test3.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM ubuntu:18.04
+FROM debian
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 

--- a/test3.Dockerfile
+++ b/test3.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM debian
+FROM ubuntu:18.04
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 

--- a/test3.Dockerfile
+++ b/test3.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 


### PR DESCRIPTION
The current `Dockerfiles` (for testing purposes) uses the `ubuntu` image and causes the following error: 

```
Sending build context to Docker daemon  516.1kB
Step 1/5 : FROM ubuntu:20.04
manifest for ubuntu:20.04 not found
```

This `PR` changes `ubuntu` to `debian` in order to address this issue. 