### PR TITLE
feat: update default image to support arm resource class

### DIFF
--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -5,13 +5,20 @@ description: >
 parameters:
   image:
     type: string
-    default: ubuntu-2004:202107-02
+    default: ubuntu-2004:2022.04.1
 
   dlc:
     type: boolean
     default: false
     description: Enable Docker Layer Caching?
 
+  resource-class:
+    type: enum
+    enum: [ "medium", "large", "xlarge", "2xlarge", "arm.medium", "arm.large", "arm.xlarge", "arm.2xlarge"]
+    default: medium
+    description: Resource class.
+
 machine:
   image: <<parameters.image>>
   docker_layer_caching: <<parameters.dlc>>
+resource_class: <<parameters.resource-class>>


### PR DESCRIPTION
This `PR` updates the default image for the `machine` executor to support `arm64` it also adds the `resource-class` parameter to the executor as well. 