### PR TITLE
fix/docker-tag-args split

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -212,7 +212,7 @@ jobs:
           extra_build_args: --build-arg COMMIT_HASH=$CIRCLE_SHA1
   test-build-bash-substitution:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
     environment:
       DOCKER_ACCOUNT: CPEOrbTesting
       DOCKER_REPO: docker_orb_test
@@ -221,8 +221,9 @@ jobs:
       - setup_remote_docker
       - docker/build:
           dockerfile: test3.Dockerfile
-          image: ${DOCKER_ACCOUNT,,}/${DOCKER_REPO/_/-}
-          tag: ${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:10}
+          image: ${DOCKER_ACCOUNT,,}/${DOCKER_REPO,,/_/-}
+          tag: ${CIRCLE_BUILD_NUM,,}-${CIRCLE_SHA1:0:10}
+          extra_build_args: --build-arg COMMIT_HASH=$CIRCLE_SHA1
   test-dockerlint:
     docker:
       - image: cimg/node:17.7.2
@@ -320,6 +321,8 @@ workflows:
             - test-create-workspace
           filters: *filters
       - test-build-with-args:
+          filters: *filters
+      - test-build-bash-substitution:
           filters: *filters
 
       # begin test-install-docker-compose

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -39,7 +39,8 @@ promotion_requires: &promotion_requires
     test-machine-latest,
     test-machine-old,
     test-build-command-workspace,
-    test-build-with-args
+    test-build-with-args,
+    test-build-bash-substitution
   ]
 
 filters: &filters
@@ -209,6 +210,19 @@ jobs:
           image: cpeorbtesting/docker-orb-test
           tag: $CIRCLE_BUILD_NUM-$CIRCLE_SHA1
           extra_build_args: --build-arg COMMIT_HASH=$CIRCLE_SHA1
+  test-build-bash-substitution:
+    docker:
+      - image: cimg/base:stable
+    environment:
+      DOCKER_ACCOUNT: CPEOrbTesting
+      DOCKER_REPO: docker_orb_test
+    steps:
+      - checkout
+      - setup_remote_docker
+      - docker/build:
+          dockerfile: test3.Dockerfile
+          image: ${DOCKER_ACCOUNT,,}/${DOCKER_REPO/_/-}
+          tag: ${CIRCLE_BUILD_NUM}-${CIRCLE_SHA1:0:10}
   test-dockerlint:
     docker:
       - image: cimg/node:17.7.2

--- a/src/examples/with-bash-substitution.yml
+++ b/src/examples/with-bash-substitution.yml
@@ -1,0 +1,15 @@
+description: >
+  Build/publish a Docker image bash substitution
+
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  workflows:
+    build-docker-image-only:
+      jobs:
+        - docker/publish:
+            image:  ${CIRCLE_PROJECT_USERNAME,,}/${CIRCLE_PROJECT_REPONAME/_/-}
+            tag: ${CIRCLE_SHA1:0:10}

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -21,6 +21,7 @@ parse_tags_to_docker_arg() {
     else
       docker_arg="$docker_arg --tag=\"$PARAM_REGISTRY/$PARAM_IMAGE:$tag\""
     fi
+    echo "DA: $docker_arg"
   done
 
   # Set IFS to null to stop "," from breaking bash substitution

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -23,6 +23,8 @@ parse_tags_to_docker_arg() {
     fi
   done
 
+  # Set IFS to null to stop "," from breaking bash substitution
+  local IFS=
   DOCKER_TAGS_ARG="$(eval echo $docker_arg)"
 }
 

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -21,7 +21,6 @@ parse_tags_to_docker_arg() {
     else
       docker_arg="$docker_arg --tag=\"$PARAM_REGISTRY/$PARAM_IMAGE:$tag\""
     fi
-    echo "DA: $docker_arg"
   done
 
   # Set IFS to null to stop "," from breaking bash substitution

--- a/test3.Dockerfile
+++ b/test3.Dockerfile
@@ -11,7 +11,6 @@ ARG COMMIT_HASH
 
 # Change default shell from Dash to Bash
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-
 RUN if [[ "${COMMIT_HASH}" =~ ^[0-9a-f]{5,40}$ ]]; then \
     echo "Success: COMMIT_HASH is valid commit hash"; \
   else \


### PR DESCRIPTION
### Motivation, issues
Issue comes when the PARAM_IMAGE, PARAM_REGISTRY or PARAM_TAG includes a ,

This can happen if the CircleCI parameter value is set to a variable which may include some bash substitution.

### Description
If `PARAM_IMAGE`, `PARAM_REGISTRY` or `PARAM_TAG` includes a , it can cause an issue when setting `DOCKER_TAGS_ARG` as those values will be split.

If using bash substitution like `${PARAM_IMAGE,,}` it will fail because of the IFS.