### PR TITLE
fix: non up-to-date executor causing apt-get issues

### DIFF
--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   image:
     type: string
-    default: ubuntu-2004:2022.04.1
+    default: ubuntu-2204:2023.02.1
 
   dlc:
     type: boolean


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation

Attempting to fix basic Dockerfile failing to build:

```
FROM debian:bookworm-slim
RUN apt-get update
```

### Description

Bumping versions of underlying executor for build job.