### PR TITLE
fix: macOS test executors

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -618,10 +618,12 @@ workflows:
 executors:
   macos-old:
     macos:
-      xcode: 11.7.0
+      xcode: 14.2.0
+    resource_class: medium
   macos-latest:
     macos:
-      xcode: 14.0.0
+      xcode: 15.0.0
+      resource_class: macos.x86.medium.gen2
   docker-old:
     docker:
       - image: cimg/base:2020.08-20.04


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

The `macos-old` executor used in this orb's tests was sunsetted. Unfortunately we cannot use M1 executors at the moment because the orb does not support multi-arch.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
