### PR TITLE
Remove --progress flag since it doesn't work for recent Windows

### DIFF
--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -66,10 +66,6 @@ if [ -n "$PARAM_CACHE_FROM" ]; then
   build_args+=("--cache-from=$PARAM_CACHE_FROM")
 fi
 
-if [ "$PARAM_USE_BUILDKIT" -eq 1 ]; then
-  build_args+=("--progress=plain")
-fi
-
 # The context must be the last argument.
 build_args+=("$PARAM_DOCKER_CONTEXT")
 


### PR DESCRIPTION
The --progress flag is not supported on the more recent Windows machine builds
