### PR TITLE
Add cache_to option in the build and publish commands

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -8,9 +8,11 @@ promotion_requires: &promotion_requires
     test-check-command-docker,
     test-check-command-machine,
     test-check-command-macos,
+    test-check-command-machine-arm,
     test-credentials-store-docker,
     test-credentials-store-machine,
     test-credentials-store-macos,
+    test-credentials-store-machine-arm,
     test-credentials-store-docker-custom-tag,
     test-credentials-store-machine-custom-tag,
     test-credentials-store-macos-custom-tag,
@@ -122,12 +124,17 @@ jobs:
         type: env_var_name
       use-docker-credentials-store:
         type: boolean
+      platform:
+        default: amd64
+        type: enum
+        enum: [amd64, arm64]
     executor: <<parameters.executor>>
     steps:
       - docker/check:
           docker-username: <<parameters.docker-username>>
           docker-password: <<parameters.docker-password>>
           use-docker-credentials-store: <<parameters.use-docker-credentials-store>>
+          platform: <<parameters.platform>>
   test-credentials-store:
     parameters:
       executor:
@@ -143,11 +150,16 @@ jobs:
       release-tag:
         type: string
         default: ""
+      platform:
+        default: amd64
+        type: enum
+        enum: [amd64, arm64]
     executor: <<parameters.executor>>
     steps:
       - docker/install-docker-credential-helper:
           helper-name: <<parameters.helper-name>>
           release-tag: <<parameters.release-tag>>
+          platform: <<parameters.platform>>
       - docker/configure-docker-credentials-store:
           helper-name: <<parameters.helper-name>>
       - run:
@@ -359,6 +371,14 @@ workflows:
           use-docker-credentials-store: true
           filters: *filters
       - test-check-command:
+          name: test-check-command-machine-arm
+          executor: machine-arm
+          context: cimg-docker-image-building
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_TOKEN
+          use-docker-credentials-store: true
+          filters: *filters
+      - test-check-command:
           name: test-check-command-macos
           executor: macos-latest
           context: cimg-docker-image-building
@@ -385,6 +405,14 @@ workflows:
           context: cimg-docker-image-building
           docker-username: DOCKER_USER
           docker-password: DOCKER_TOKEN
+          filters: *filters
+      - test-credentials-store:
+          name: test-credentials-store-machine-arm
+          executor: machine-latest
+          context: cimg-docker-image-building
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_TOKEN
+          platform: arm64
           filters: *filters
       - test-credentials-store:
           name: test-credentials-store-macos

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -502,6 +502,7 @@ workflows:
           image: ccitest/docker-orb-test
           tag: $CIRCLE_SHA1
           cache_to: ccitest/docker-orb-test:cache-big,ccitest/docker-orb-test:cache2-big
+          cache_from: ccitest/docker-orb-test:cache2-big
           docker-username: DOCKER_USER
           docker-password: DOCKER_TOKEN
           pre-steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -502,7 +502,7 @@ workflows:
           dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test
           tag: $CIRCLE_SHA1
-          cache_to: ccitest/docker-orb-test-big:cache,ccitest/docker-orb-test-big:cache2
+          cache_to: ccitest/docker-orb-test:cache-big,ccitest/docker-orb-test:cache2-big
           docker-username: DOCKER_USER
           docker-password: DOCKER_TOKEN
           pre-steps:
@@ -521,7 +521,7 @@ workflows:
           dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test
           tag: $CIRCLE_SHA1
-          cache_from: ccitest/docker-orb-test-big:cache
+          cache_from: ccitest/docker-orb-test:cache-big
           docker-username: DOCKER_USER
           docker-password: DOCKER_TOKEN
           pre-steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -635,7 +635,6 @@ executors:
   macos-latest:
     macos:
       xcode: 15.2.0
-      resource_class: macos.x86.medium.gen2
   docker-old:
     docker:
       - image: cimg/base:2020.08-20.04

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -124,7 +124,7 @@ jobs:
         type: env_var_name
       use-docker-credentials-store:
         type: boolean
-      platform:
+      arch:
         default: amd64
         type: enum
         enum: [amd64, arm64]
@@ -134,7 +134,7 @@ jobs:
           docker-username: <<parameters.docker-username>>
           docker-password: <<parameters.docker-password>>
           use-docker-credentials-store: <<parameters.use-docker-credentials-store>>
-          platform: <<parameters.platform>>
+          arch: <<parameters.arch>>
   test-credentials-store:
     parameters:
       executor:
@@ -150,7 +150,7 @@ jobs:
       release-tag:
         type: string
         default: ""
-      platform:
+      arch:
         default: amd64
         type: enum
         enum: [amd64, arm64]
@@ -159,7 +159,7 @@ jobs:
       - docker/install-docker-credential-helper:
           helper-name: <<parameters.helper-name>>
           release-tag: <<parameters.release-tag>>
-          platform: <<parameters.platform>>
+          arch: <<parameters.arch>>
       - docker/configure-docker-credentials-store:
           helper-name: <<parameters.helper-name>>
       - run:
@@ -376,6 +376,7 @@ workflows:
           context: cimg-docker-image-building
           docker-username: DOCKER_USER
           docker-password: DOCKER_TOKEN
+          arch: arm64
           use-docker-credentials-store: true
           filters: *filters
       - test-check-command:
@@ -408,11 +409,11 @@ workflows:
           filters: *filters
       - test-credentials-store:
           name: test-credentials-store-machine-arm
-          executor: machine-latest
+          executor: machine-arm
           context: cimg-docker-image-building
           docker-username: DOCKER_USER
           docker-password: DOCKER_TOKEN
-          platform: arm64
+          arch: arm64
           filters: *filters
       - test-credentials-store:
           name: test-credentials-store-macos

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -496,7 +496,7 @@ workflows:
           filters: *filters
       - docker/publish:
           name: publish-docker-save-cache
-          executor: machine-arm
+          executor: machine-latest
           context: cimg-docker-image-building
           dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test
@@ -515,7 +515,7 @@ workflows:
           name: publish-docker-cache
           requires:
             - publish-docker-save-cache
-          executor: machine-arm
+          executor: machine-latest
           context: cimg-docker-image-building
           dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -468,16 +468,33 @@ workflows:
           use-docker-credentials-store: true
           filters: *filters
       - docker/publish:
-          name: publish-docker-cache
-          requires:
-            - publish-docker
+          name: publish-docker-save-cache
           executor: docker-latest
           context: cimg-docker-image-building
           use-remote-docker: true
           dockerfile: test.Dockerfile
           image: ccitest/docker-orb-test
           tag: $CIRCLE_SHA1
-          cache_from: ccitest/docker-orb-test:$CIRCLE_SHA1
+          cache_to: ccitest/docker-orb-test:cache,ccitest/docker-orb-test:cache2
+          docker-username: DOCKER_USER
+          docker-password: DOCKER_TOKEN
+          pre-steps:
+            - docker/install-docker-credential-helper:
+                # release-tag: v0.6.3
+            - docker/configure-docker-credentials-store:
+                helper-name: pass
+          filters: *filters
+      - docker/publish:
+          name: publish-docker-cache
+          requires:
+            - publish-docker-save-cache
+          executor: docker-latest
+          context: cimg-docker-image-building
+          use-remote-docker: true
+          dockerfile: test.Dockerfile
+          image: ccitest/docker-orb-test
+          tag: $CIRCLE_SHA1
+          cache_from: ccitest/docker-orb-test:cache
           docker-username: DOCKER_USER
           docker-password: DOCKER_TOKEN
           pre-steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -496,7 +496,7 @@ workflows:
           filters: *filters
       - docker/publish:
           name: publish-docker-save-cache
-          executor: machine-latest
+          executor: machine-arm
           context: cimg-docker-image-building
           dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test
@@ -515,7 +515,7 @@ workflows:
           name: publish-docker-cache
           requires:
             - publish-docker-save-cache
-          executor: machine-latest
+          executor: machine-arm
           context: cimg-docker-image-building
           dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -496,9 +496,8 @@ workflows:
           filters: *filters
       - docker/publish:
           name: publish-docker-save-cache
-          executor: docker-latest
+          executor: machine-latest
           context: cimg-docker-image-building
-          use-remote-docker: true
           dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test
           tag: $CIRCLE_SHA1
@@ -515,9 +514,8 @@ workflows:
           name: publish-docker-cache
           requires:
             - publish-docker-save-cache
-          executor: docker-latest
+          executor: machine-latest
           context: cimg-docker-image-building
-          use-remote-docker: true
           dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test
           tag: $CIRCLE_SHA1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -499,10 +499,10 @@ workflows:
           executor: docker-latest
           context: cimg-docker-image-building
           use-remote-docker: true
-          dockerfile: test.Dockerfile
+          dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test
           tag: $CIRCLE_SHA1
-          cache_to: ccitest/docker-orb-test:cache,ccitest/docker-orb-test:cache2
+          cache_to: ccitest/docker-orb-test-big:cache,ccitest/docker-orb-test-big:cache2
           docker-username: DOCKER_USER
           docker-password: DOCKER_TOKEN
           pre-steps:
@@ -518,10 +518,10 @@ workflows:
           executor: docker-latest
           context: cimg-docker-image-building
           use-remote-docker: true
-          dockerfile: test.Dockerfile
+          dockerfile: test4.Dockerfile
           image: ccitest/docker-orb-test
           tag: $CIRCLE_SHA1
-          cache_from: ccitest/docker-orb-test:cache
+          cache_from: ccitest/docker-orb-test-big:cache
           docker-username: DOCKER_USER
           docker-password: DOCKER_TOKEN
           pre-steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -25,7 +25,6 @@ promotion_requires: &promotion_requires
     test-install-docker-tools-docker-latest,
     test-install-docker-tools-docker-old,
     test-install-docker-tools-macos-latest,
-    test-install-docker-tools-macos-old,
     test-install-docker-tools-machine-latest,
     test-install-docker-tools-machine-old,
     test-install-docker-tools-machine-arm,
@@ -35,7 +34,6 @@ promotion_requires: &promotion_requires
     test-docker-latest,
     test-docker-old,
     test-macos-latest,
-    test-macos-old,
     test-machine-latest,
     test-machine-old,
     test-machine-arm,
@@ -597,7 +595,7 @@ workflows:
           name: test-install-docker-tools-<< matrix.executor >>
           matrix:
             parameters:
-              executor: [macos-latest, macos-old]
+              executor: [macos-latest]
           install-goss: false
           filters: *filters
       # end test-install-docker-tools
@@ -613,7 +611,7 @@ workflows:
           name: test-<< matrix.executor >>
           matrix:
             parameters:
-              executor: [macos-latest, macos-old, machine-arm]
+              executor: [macos-latest, machine-arm]
           install-goss: false
           filters: *filters
       # end test
@@ -634,10 +632,6 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 executors:
-  macos-old:
-    macos:
-      xcode: 14.3.1
-    resource_class: macos.x86.medium.gen2
   macos-latest:
     macos:
       xcode: 15.2.0

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -60,13 +60,17 @@ parameters:
     description: >
       Comma-separated list of images, images will first be pulled, then
       passed as the --cache-from build argument.
-      https://docs.docker.com/reference/cli/docker/buildx/build/#cache-from
+      This parameter only support registry type, the accepted syntax is:
+      cache_from: user/app:cache,user/app2:cache2
+
   cache_to:
     type: string
     default: ""
     description: >
       Comman-separated list of images where cache will be pushed to.
-      https://docs.docker.com/reference/cli/docker/buildx/build/#cache-to
+      This parameter only support registry type, the accepted syntax is:
+      cache_to: user/app:cache,user/app2:cache2
+
   debug:
     type: boolean
     default: false

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -59,9 +59,14 @@ parameters:
     default: ""
     description: >
       Comma-separated list of images, images will first be pulled, then
-      passed as the --cache-from build argument
-      https://docs.docker.com/engine/reference/commandline/build/
-
+      passed as the --cache-from build argument.
+      https://docs.docker.com/reference/cli/docker/buildx/build/#cache-from
+  cache_to:
+    type: string
+    default: ""
+    description: >
+      Comman-separated list of images where cache will be pushed to.
+      https://docs.docker.com/reference/cli/docker/buildx/build/#cache-to
   debug:
     type: boolean
     default: false
@@ -128,6 +133,7 @@ steps:
       no_output_timeout: << parameters.no_output_timeout >>
       environment:
         PARAM_CACHE_FROM: <<parameters.cache_from>>
+        PARAM_CACHE_TO: <<parameters.cache_to>>
         PARAM_DOCKER_CONTEXT: <<parameters.docker-context>>
         PARAM_DOCKERFILE_NAME: <<parameters.dockerfile>>
         PARAM_DOCKERFILE_PATH: <<parameters.path>>

--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -9,15 +9,15 @@ parameters:
     default: docker.io
     description: Name of registry to use, defaults to docker.io
 
-  platform:
+  arch:
     type: enum
     default: amd64
     enum: [amd64, arm64]
     description: |
-      Which architecture platform is being used.
+      Which architecture is being used.
       Values accepted are amd64 and arm64. Defaults to amd64.
       When running on MacOS arm64 will be used.
-    
+
   docker-username:
     type: env_var_name
     default: DOCKER_LOGIN
@@ -42,7 +42,7 @@ steps:
       condition: <<parameters.use-docker-credentials-store>>
       steps:
         - install-docker-credential-helper:
-            platform: <<parameters.platform>>
+            arch: <<parameters.arch>>
         - configure-docker-credentials-store
 
   - run:

--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -9,6 +9,15 @@ parameters:
     default: docker.io
     description: Name of registry to use, defaults to docker.io
 
+  platform:
+    type: enum
+    default: amd64
+    enum: [amd64, arm64]
+    description: |
+      Which architecture platform is being used.
+      Values accepted are amd64 and arm64. Defaults to amd64.
+      When running on MacOS arm64 will be used.
+    
   docker-username:
     type: env_var_name
     default: DOCKER_LOGIN
@@ -32,7 +41,8 @@ steps:
   - when:
       condition: <<parameters.use-docker-credentials-store>>
       steps:
-        - install-docker-credential-helper
+        - install-docker-credential-helper:
+            platform: <<parameters.platform>>
         - configure-docker-credentials-store
 
   - run:

--- a/src/commands/install-docker-credential-helper.yml
+++ b/src/commands/install-docker-credential-helper.yml
@@ -19,7 +19,15 @@ parameters:
       Note: Pre or alpha releases cannot be specified.
     type: string
     default: ""
-
+  platform:
+    type: enum
+    default: amd64
+    enum: [amd64, arm64]
+    description: |
+      Which architecture platform is being used.
+      Values accepted are amd64 and arm64. Defaults to amd64.
+      When running on MacOS arm64 will be used.
+    
 steps:
   - run:
       name: Install Docker credential helper
@@ -27,4 +35,5 @@ steps:
         PARAM_HELPER_NAME: << parameters.helper-name >>
         PARAM_RELEASE_TAG: << parameters.release-tag >>
         SCRIPT_UTILS: <<include(scripts/utils.sh)>>
+        PLATFORM: << parameters.platform >>
       command: << include(scripts/install-docker-credential-helper.sh) >>

--- a/src/commands/install-docker-credential-helper.yml
+++ b/src/commands/install-docker-credential-helper.yml
@@ -19,21 +19,20 @@ parameters:
       Note: Pre or alpha releases cannot be specified.
     type: string
     default: ""
-  platform:
+  arch:
     type: enum
     default: amd64
     enum: [amd64, arm64]
     description: |
-      Which architecture platform is being used.
+      Which architecture is being used.
       Values accepted are amd64 and arm64. Defaults to amd64.
       When running on MacOS arm64 will be used.
-    
 steps:
   - run:
       name: Install Docker credential helper
       environment:
         PARAM_HELPER_NAME: << parameters.helper-name >>
         PARAM_RELEASE_TAG: << parameters.release-tag >>
+        PARAM_ARCH: << parameters.arch >>
         SCRIPT_UTILS: <<include(scripts/utils.sh)>>
-        PLATFORM: << parameters.platform >>
       command: << include(scripts/install-docker-credential-helper.sh) >>

--- a/src/examples/with-cache-to.yml
+++ b/src/examples/with-cache-to.yml
@@ -1,0 +1,15 @@
+description: >
+  Build/publish a Docker image using --cache-to
+usage:
+  version: 2.1
+
+  orbs:
+    docker: circleci/docker@x.y.z
+
+  workflows:
+    build-docker-image-only:
+      jobs:
+        - docker/publish:
+            image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+            tag: latest
+            cache_to: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:cache

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -102,7 +102,7 @@ parameters:
     default: ""
     description: >
       Comman-separated list of images where cache will be pushed to.
-      https://docs.docker.com/reference/cli/docker/buildx/build/#cache-to    
+      https://docs.docker.com/reference/cli/docker/buildx/build/#cache-to
 
   after_checkout:
     description: Optional steps to run after checking out the code

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -96,7 +96,13 @@ parameters:
     default: ""
     description: >
       Comma-separated list of images to pull before build for --cache-from
-      https://docs.docker.com/engine/reference/commandline/build/
+      https://docs.docker.com/engine/reference/commandline/build/#cache-from
+  cache_to:
+    type: string
+    default: ""
+    description: >
+      Comman-separated list of images where cache will be pushed to.
+      https://docs.docker.com/reference/cli/docker/buildx/build/#cache-to    
 
   after_checkout:
     description: Optional steps to run after checking out the code
@@ -200,6 +206,7 @@ steps:
       image: <<parameters.image>>
       tag: <<parameters.tag>>
       cache_from: <<parameters.cache_from>>
+      cache_to: <<parameters.cache_to>>
       extra_build_args: <<parameters.extra_build_args>>
       lint-dockerfile: <<parameters.lint-dockerfile>>
       treat-warnings-as-errors: <<parameters.treat-warnings-as-errors>>

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -96,13 +96,16 @@ parameters:
     default: ""
     description: >
       Comma-separated list of images to pull before build for --cache-from
-      https://docs.docker.com/engine/reference/commandline/build/#cache-from
+      This parameter only support registry type, the accepted syntax is:
+      cache_from: user/app:cache,user/app2:cache2
+
   cache_to:
     type: string
     default: ""
     description: >
       Comman-separated list of images where cache will be pushed to.
-      https://docs.docker.com/reference/cli/docker/buildx/build/#cache-to
+      This parameter only support registry type, the accepted syntax is:
+      cache_to: user/app:cache,user/app2:cache2
 
   after_checkout:
     description: Optional steps to run after checking out the code
@@ -140,7 +143,6 @@ parameters:
     default: DOCKER_PASSWORD
     description: >
       Name of environment variable storing your Docker password
-
 
   attach-at:
     type: string

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -37,7 +37,7 @@ pull_images_from_cache() {
     docker pull ${image} || true
   done
 }
-set -x
+
 if ! parse_tags_to_docker_arg; then
   echo "Unable to parse provided tags."
   echo "Check your \"tag\" parameter or refer to the docs and try again: https://circleci.com/developer/orbs/orb/circleci/docker."
@@ -78,7 +78,7 @@ build_args+=("$PARAM_DOCKER_CONTEXT")
 old_ifs="$IFS"
 IFS=' '
 
-
+set -x
 # shellcheck disable=SC2048 # We want word splitting here.
 docker buildx build ${build_args[*]}
 set +x

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -66,6 +66,10 @@ if [ -n "$PARAM_CACHE_FROM" ]; then
   build_args+=("--cache-from=$PARAM_CACHE_FROM")
 fi
 
+if [ -n "$PARAM_CACHE_TO" ]; then
+  build_args+=("--cache-to=$PARAM_CACHE_TO")
+fi
+
 # The context must be the last argument.
 build_args+=("$PARAM_DOCKER_CONTEXT")
 

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -69,7 +69,7 @@ fi
 if [ -n "$PARAM_CACHE_TO" ]; then
   docker buildx create --name cache --use
   docker buildx use cache
-  build_args+=("--cache-to=$PARAM_CACHE_TO")
+  build_args+=("--cache-to=$PARAM_CACHE_TO" --load)
 fi
 
 # The context must be the last argument.

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -78,7 +78,7 @@ IFS=' '
 
 set -x
 # shellcheck disable=SC2048 # We want word splitting here.
-docker build ${build_args[*]}
+docker buildx build ${build_args[*]}
 set +x
 
 IFS="$old_ifs"

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -37,7 +37,7 @@ pull_images_from_cache() {
     docker pull ${image} || true
   done
 }
-
+set -x
 if ! parse_tags_to_docker_arg; then
   echo "Unable to parse provided tags."
   echo "Check your \"tag\" parameter or refer to the docs and try again: https://circleci.com/developer/orbs/orb/circleci/docker."
@@ -78,7 +78,7 @@ build_args+=("$PARAM_DOCKER_CONTEXT")
 old_ifs="$IFS"
 IFS=' '
 
-set -x
+
 # shellcheck disable=SC2048 # We want word splitting here.
 docker buildx build ${build_args[*]}
 set +x

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -67,6 +67,8 @@ if [ -n "$PARAM_CACHE_FROM" ]; then
 fi
 
 if [ -n "$PARAM_CACHE_TO" ]; then
+  docker buildx create --name cache --use
+  docker buildx use cache
   build_args+=("--cache-to=$PARAM_CACHE_TO")
 fi
 

--- a/src/scripts/install-docker-credential-helper.sh
+++ b/src/scripts/install-docker-credential-helper.sh
@@ -11,7 +11,7 @@ if uname | grep -q "Darwin"; then
   arch="arm64"
 else 
   platform="linux"
-  arch="$PLATFORM"
+  arch="$PARAM_ARCH"
 fi
 
 # Infer helper name from the platform

--- a/src/scripts/install-docker-credential-helper.sh
+++ b/src/scripts/install-docker-credential-helper.sh
@@ -6,8 +6,12 @@ expand_env_vars_with_prefix "PARAM_"
 
 HELPER_NAME="$PARAM_HELPER_NAME"
 
-if uname | grep -q "Darwin"; then platform="darwin"
-else platform="linux"
+if uname | grep -q "Darwin"; then 
+  platform="darwin"
+  arch="arm64"
+else 
+  platform="linux"
+  arch="$PLATFORM"
 fi
 
 # Infer helper name from the platform
@@ -75,11 +79,11 @@ minor_version="$(echo "$RELEASE_VERSION" | cut -d. -f2)"
 download_base_url="$base_url/download/${RELEASE_VERSION}/${HELPER_FILENAME}-${RELEASE_VERSION}"
 
 if [ "$minor_version" -gt 6 ]; then
-  DOWNLOAD_URL="$download_base_url.$platform-amd64"
+  DOWNLOAD_URL="$download_base_url.$platform-$arch"
   echo "Downloading from url: $DOWNLOAD_URL"
   curl -L -o "${HELPER_FILENAME}" "$DOWNLOAD_URL"
 else
-  DOWNLOAD_URL="$download_base_url-amd64.tar.gz"
+  DOWNLOAD_URL="$download_base_url-$arch.tar.gz"
   echo "Downloading from url: $DOWNLOAD_URL"
   curl -L -o "${HELPER_FILENAME}_archive" "$DOWNLOAD_URL"
   tar xvf "./${HELPER_FILENAME}_archive"

--- a/test4.Dockerfile
+++ b/test4.Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:22.04
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install common packages (same as base)
+RUN apt-get update && apt-get install -y \
+  python3.10 \
+  python3-pip \
+  curl \
+  wget \
+  git \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install common Python packages (same as base)
+RUN pip3 install --no-cache-dir --upgrade pip && \
+  pip3 install --no-cache-dir \
+  numpy \
+  pandas \
+  scikit-learn \
+  matplotlib
+
+# Install additional packages
+RUN apt-get update && apt-get install -y \
+  nodejs \
+  npm \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install TensorFlow and Keras
+RUN pip3 install --no-cache-dir tensorflow keras
+
+# Install PyTorch
+RUN pip3 install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+
+# Install some Node.js packages globally
+RUN npm install -g \
+  express \
+  lodash \
+  moment
+
+# Create large files to simulate longer build time
+RUN dd if=/dev/urandom of=/large_file_1 bs=1M count=500 && \
+  dd if=/dev/urandom of=/large_file_2 bs=1M count=500 && \
+  rm /large_file_1 /large_file_2
+
+# Set working directory
+WORKDIR /app
+
+# Create a simple Python script that uses one of the new packages
+RUN echo 'import tensorflow as tf; print(f"TensorFlow version: {tf.__version__}")' > tf_version.py
+
+CMD ["python3", "tf_version.py"]


### PR DESCRIPTION
I'm adding a new parameter to allow cache_to similar to the cache_from option.
I'm also updating the orb and tests to support new Mac Silicon and ARM architectures.