### PR TITLE
Update management of parameters with multiple arguments to be able to…

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -56,6 +56,17 @@ orbs:
   orb-tools: circleci/orb-tools@11.1
 
 jobs:
+  build-multispace-args:
+    machine:
+      image: ubuntu-2004:current
+    steps:
+      - checkout
+      - docker/install-docker
+      - docker/build:
+          dockerfile: test3.Dockerfile
+          image: docker-orb-test-temporal
+          tag: tempora-test
+          extra_build_args: --build-arg=COMMIT_HASH=$CIRCLE_SHA1 --build-arg=CARG='i am a good parameter' --build-arg=DATE=$(date +%F)
   test:
     parameters:
       executor:
@@ -305,6 +316,7 @@ jobs:
 workflows:
   test-deploy:
     jobs:
+      - build-multispace-args
       - docker/hadolint:
           name: hadolint
           ignore-rules: DL4005,DL3008,DL3009,DL3015,DL3059

--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -52,7 +52,9 @@ parameters:
     default: ""
     description: >
       Extra flags to pass to docker build. For examples, see
-      https://docs.docker.com/engine/reference/commandline/build
+      https://docs.docker.com/engine/reference/commandline/build.
+      Pass the desired args using an equal sign (=) instead of an space.
+      For example, --build-arg=ARG1=value, instead of --build-arg ARG1=vallue.
 
   cache_from:
     type: string
@@ -117,16 +119,6 @@ steps:
             debug: <<parameters.debug>>
 
   - when:
-      condition: <<parameters.use-buildkit>>
-      steps:
-        - run: echo 'export DOCKER_BUILDKIT=1' >> $BASH_ENV
-
-  - when:
-      condition: <<parameters.extra_build_args>>
-      steps:
-        - run: echo 'PARAM_EXTRA_BUILD_ARGS="<<parameters.extra_build_args>>"' >> $BASH_ENV
-
-  - when:
       condition: <<parameters.attach-at>>
       steps:
         - attach_workspace:
@@ -136,6 +128,7 @@ steps:
       name: <<parameters.step-name>>
       no_output_timeout: << parameters.no_output_timeout >>
       environment:
+        EXTRA_BUILD_ARGS: <<parameters.extra_build_args>>
         PARAM_CACHE_FROM: <<parameters.cache_from>>
         PARAM_CACHE_TO: <<parameters.cache_to>>
         PARAM_DOCKER_CONTEXT: <<parameters.docker-context>>

--- a/src/examples/with-extra-build-args.yml
+++ b/src/examples/with-extra-build-args.yml
@@ -12,4 +12,4 @@ usage:
       jobs:
         - docker/publish:
             image:  $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-            extra_build_args: --build-arg FOO=bar --build-arg BAZ=qux
+            extra_build_args: --build-arg=FOO=bar --build-arg=BAZ=qux

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -90,6 +90,8 @@ parameters:
     description: >
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
+      Pass the desired args using an equal sign (=) instead of an space.
+      For example, --build-arg=ARG1=value, instead of --build-arg ARG1=vallue.
 
   cache_from:
     type: string

--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -3,7 +3,6 @@
 # Import "utils.sh".
 eval "$SCRIPT_UTILS"
 expand_env_vars_with_prefix "PARAM_"
-
 DOCKER_TAGS_ARG=""
 
 parse_tags_to_docker_arg() {
@@ -54,12 +53,12 @@ fi
 
 build_args=(
   "--file=$PARAM_DOCKERFILE_PATH/$PARAM_DOCKERFILE_NAME"
-  "$DOCKER_TAGS_ARG"
 )
 
-if [ -n "$PARAM_EXTRA_BUILD_ARGS" ]; then
-  extra_build_args="$(eval echo "$PARAM_EXTRA_BUILD_ARGS")"
-  build_args+=("$extra_build_args")
+eval 'for t in '$DOCKER_TAGS_ARG'; do build_args+=("$t"); done'
+
+if [ -n "$EXTRA_BUILD_ARGS" ]; then
+  eval 'for p in '$EXTRA_BUILD_ARGS'; do build_args+=("$p"); done'
 fi
 
 if [ -n "$PARAM_CACHE_FROM" ]; then
@@ -79,8 +78,7 @@ old_ifs="$IFS"
 IFS=' '
 
 set -x
-# shellcheck disable=SC2048 # We want word splitting here.
-docker buildx build ${build_args[*]}
+docker buildx build "${build_args[@]}"
 set +x
 
 IFS="$old_ifs"


### PR DESCRIPTION
The issue #193 indicates a problem when the arguments have spaces. 
The solution involves two parts.
1. Update the way the extra_build_args are named and passed to the script, so they quotes are not removed
2. Update the way the extra_build_args are expanded so the the independent arguments are well understood, and the quotes for values are not removed.

This change requires the extra_build_args to be named using the equal signe, so a syntax like `--build-arg ARG1=VALUE1` is not longer accepted, and it must be `--build-arg=ARG1=VALUE1`.
In theory the first syntax should be accepted as well if everything is quoted, but is not recommended to do it.
