### PR TITLE
Use latest docker for remote machine

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -497,7 +497,6 @@ workflows:
           executor: docker-latest
           context: cimg-docker-image-building
           use-remote-docker: true
-          remote-docker-version: "20.10.12"
           use-buildkit: true
           dockerfile: test.Dockerfile
           image: ccitest/docker-orb-test

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -19,7 +19,7 @@ parameters:
 
   remote-docker-version:
     type: string
-    default: "20.10.18"
+    default: "default"
     description: >
       Pick remote Docker engine version.
       Available versions can be found at: https://circleci.com/docs/2.0/building-docker-images/#docker-version.


### PR DESCRIPTION
Currently defined version is not available since end of September