### PR TITLE
feat: eval cache_to parameter to allow to use variables

### DIFF
--- a/src/scripts/build.sh
+++ b/src/scripts/build.sh
@@ -66,9 +66,11 @@ if [ -n "$PARAM_CACHE_FROM" ]; then
 fi
 
 if [ -n "$PARAM_CACHE_TO" ]; then
+  cache_to="$(eval echo $PARAM_CACHE_TO)"
+
   docker buildx create --name cache --use
   docker buildx use cache
-  build_args+=("--cache-to=$PARAM_CACHE_TO" --load)
+  build_args+=("--cache-to=$cache_to" --load)
 fi
 
 # The context must be the last argument.


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

We want to be able to use environment variables in cache_to parameter.

### Description

Eval cache_to parameter