### PR TITLE
[PIE-42] Bump default executor to python:3.13

### DIFF
--- a/src/executors/docker.yml
+++ b/src/executors/docker.yml
@@ -9,7 +9,7 @@ parameters:
 
   tag:
     type: string
-    default: "3.11"
+    default: "3.13"
     description: Image tag
 
 docker:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
Python 3.11 is near EOL.

### Description

Bump default executor to `python:3.13`

### Breaking changes

Old tag	3.11
New tag	3.13

To retain old behavior, pin the tag explicitly in your config:
```yaml
executor:
  name: docker/default
  tag: "3.11"
```
