### PR TITLE
Add retry support to docker/check login [semver:patch]

### DIFF
--- a/src/commands/check.yml
+++ b/src/commands/check.yml
@@ -37,6 +37,13 @@ parameters:
       Configure Docker to use a credentials store.
       This option is only supported on Ubuntu/Debian/macOS platforms.
 
+  retries:
+    type: integer
+    default: 3
+    description: >
+      Number of times to retry docker login after a failure. The command
+      makes up to retries + 1 attempts with an increasing delay between tries.
+
 steps:
   - when:
       condition: <<parameters.use_docker_credentials_store>>
@@ -51,5 +58,6 @@ steps:
         PARAM_REGISTRY: <<parameters.registry>>
         PARAM_DOCKER_USERNAME: <<parameters.docker_username>>
         PARAM_DOCKER_PASSWORD: <<parameters.docker_password>>
+        PARAM_RETRIES: <<parameters.retries>>
         SCRIPT_UTILS: <<include(scripts/utils.sh)>>
       command: <<include(scripts/check.sh)>>

--- a/src/scripts/check.sh
+++ b/src/scripts/check.sh
@@ -4,4 +4,24 @@
 eval "$SCRIPT_UTILS"
 expand_env_vars_with_prefix "PARAM_"
 
-echo "${!PARAM_DOCKER_PASSWORD}" | docker login -u "${!PARAM_DOCKER_USERNAME}" --password-stdin "$PARAM_REGISTRY"
+retries="${PARAM_RETRIES:-3}"
+attempt=1
+max_attempts=$((retries + 1))
+exit_code=1
+
+while [ "$attempt" -le "$max_attempts" ]; do
+  echo "Attempt ${attempt}/${max_attempts}: docker login"
+  if ( set -x; echo "${!PARAM_DOCKER_PASSWORD}" | docker login -u "${!PARAM_DOCKER_USERNAME}" --password-stdin "$PARAM_REGISTRY" ); then
+    exit 0
+  fi
+  exit_code=$?
+  echo "docker login failed with exit code ${exit_code}"
+
+  if [ "$attempt" -lt "$max_attempts" ]; then
+    echo "Retrying in ${attempt} second(s)..."
+    sleep "$attempt"
+  fi
+  attempt=$((attempt + 1))
+done
+
+exit "$exit_code"


### PR DESCRIPTION
## Summary

- Add a `retries` parameter to the `check` command (default: 3)
- Retry `docker login` up to `retries + 1` times with an increasing delay between attempts
- Log each attempt with `set -x` so failures are easier to diagnose in build output

Closes #217

## Motivation

Transient registry or network errors can cause a single `docker login` attempt to fail even when credentials and configuration are correct. A manual pipeline rerun often succeeds. Retrying inside the command avoids unnecessary build failures for this class of error.

## Test plan

- [ ] `orb-tools/lint`, `orb-tools/pack`, and `orb-tools/review` pass in CI
- [ ] `docker/check` succeeds against a valid registry with default retries
- [ ] Simulated login failure shows retry logging and exits with the last attempt status code