### PR TITLE
patch: bump ubuntu from 18.04 to 22.04

### DIFF
--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 


### PR DESCRIPTION
A riddle: what's old, full of holes, and running in your pipeline? Not anymore.

Updates `ubuntu` from `18.04` to `22.04` in `test.Dockerfile`.

No functional changes. Just security.

---
*Quietly yours.*