### PR TITLE
patch: bump ubuntu from 18.04 to 22.04

### DIFF
--- a/test2.Dockerfile
+++ b/test2.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 


### PR DESCRIPTION
Knock knock. Who's there? A base image update you've been putting off.

Updates `ubuntu` from `18.04` to `22.04` in `test2.Dockerfile`.

No functional changes. Just security.

---
*Quietly yours.*