### PR TITLE
patch: bump ubuntu from 18.04 to 22.04

### DIFF
--- a/test3.Dockerfile
+++ b/test3.Dockerfile
@@ -3,7 +3,7 @@
 # The Ubuntu-based CircleCI Docker Image. Only use Ubuntu Long-Term Support
 # (LTS) releases.
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 LABEL maintainer="CircleCI <support@circleci.com>"
 


### PR DESCRIPTION
Three things in life are certain: death, taxes, and outdated base images.

Updates `ubuntu` from `18.04` to `22.04` in `test3.Dockerfile`.

No functional changes. Just security.

---
*Until next time.*