### PR TITLE
patch: bump ubuntu from 22.04 to 26.10

### DIFF
--- a/test4.Dockerfile
+++ b/test4.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:26.10
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Some bring flowers. I bring version bumps.

Updates `ubuntu` from `22.04` to `26.10` in `test4.Dockerfile`.

No functional changes. Just security.

---
*Yours in security.*